### PR TITLE
fix: 云上报错无法正确展示和入库的问题

### DIFF
--- a/cmd/cloud-server/service/sync/time_sync.go
+++ b/cmd/cloud-server/service/sync/time_sync.go
@@ -136,13 +136,14 @@ func allAccountSync(kt *kit.Kit, cliSet *client.ClientSet, vendor enumor.Vendor)
 			}
 			if err != nil {
 				if resName != "" {
-					if err := sd.ResSyncStatusFailed(resName, err.Error()); err != nil {
+					if err := sd.ResSyncStatusFailed(resName, err); err != nil {
 						logs.Errorf("%s sync %s res detail failed, err: %v, accountID: %s, rid: %s", vendor,
 							resName, err, one.ID, kt.Rid)
 						return
 					}
 				}
 				logs.Errorf("sync %s all resource failed, err: %v, accountID: %s, rid: %s", vendor, err, one.ID, kt.Rid)
+				// 跳过当前账号
 				continue
 			}
 

--- a/pkg/adaptor/azure/error.go
+++ b/pkg/adaptor/azure/error.go
@@ -77,7 +77,7 @@ func extractGraphError(graphErr error) error {
 	switch {
 	case errors.As(graphErr, &oDataError):
 		if terr := oDataError.GetErrorEscaped(); terr != nil {
-			return fmt.Errorf("%v,%v,%v", oDataError, converter.PtrToVal(terr.GetCode()),
+			return fmt.Errorf("%v, %v, %v", oDataError, converter.PtrToVal(terr.GetCode()),
 				converter.PtrToVal(terr.GetMessage()))
 		}
 		return oDataError


### PR DESCRIPTION
一些云上错误信息中会包含换行符，直接用err.Error()方法获取错误状态并作为错误原因字段，将无法处理Message中的换行符，导致后续json序列化报错