### PR TITLE
fix: 优化资源下安全组列表的tab切换相关业务

### DIFF
--- a/front/src/store/useResourceAccountStore.ts
+++ b/front/src/store/useResourceAccountStore.ts
@@ -35,7 +35,8 @@ export type IAccount = {
 
 export const useResourceAccountStore = defineStore('useResourceAccountStore', () => {
   const resourceAccount = ref<IAccount>(null);
-  const currentVendor = ref<VendorEnum>(null);
+  const currentVendor = ref<VendorEnum>(null); // 当前选中的云厂商
+  const currentAccountVendor = ref<VendorEnum>(null); // 当前选中账号的 vendor
 
   const setResourceAccount = (val: IAccount) => {
     resourceAccount.value = val;
@@ -43,11 +44,16 @@ export const useResourceAccountStore = defineStore('useResourceAccountStore', ()
   const setCurrentVendor = (val: VendorEnum) => {
     currentVendor.value = val;
   };
+  const setCurrentAccountVendor = (val: VendorEnum) => {
+    currentAccountVendor.value = val;
+  };
 
   return {
     resourceAccount,
     setResourceAccount,
     currentVendor,
     setCurrentVendor,
+    currentAccountVendor,
+    setCurrentAccountVendor,
   };
 });

--- a/front/src/views/resource/resource-manage/account/accountList/components/VendorAccounts/index.tsx
+++ b/front/src/views/resource/resource-manage/account/accountList/components/VendorAccounts/index.tsx
@@ -66,14 +66,16 @@ export default defineComponent({
     // 点击云厂商
     const handleClickVendor = (vendor: VendorEnum) => {
       resourceAccountStore.setCurrentVendor(vendor);
+      resourceAccountStore.setCurrentAccountVendor(null);
       props.handleExpand(vendor);
       props.handleSelect('');
     };
 
     // 点击账号
-    const handleClickAccount = (id: string) => {
+    const handleClickAccount = (id: string, vendor: VendorEnum) => {
       props.handleSelect(id);
       resourceAccountStore.setCurrentVendor(null);
+      resourceAccountStore.setCurrentAccountVendor(vendor);
     };
 
     watch(
@@ -119,11 +121,11 @@ export default defineComponent({
                   <div class='vendor-account-count'>{count}</div>
                 </div>
                 <div class={`account-list-wrap${isExpand ? ' expand' : ''}`}>
-                  {accounts.map(({ sync_status, name, id }) => (
+                  {accounts.map(({ sync_status, name, id, vendor }) => (
                     <div
                       class={`account-item${route.query.accountId === id ? ' active' : ''}`}
                       key={id}
-                      onClick={() => handleClickAccount(id)}>
+                      onClick={() => handleClickAccount(id, vendor)}>
                       <img
                         src={sync_status === 'sync_success' ? successAccount : failedAccount}
                         alt=''

--- a/front/src/views/resource/resource-manage/account/accountList/index.tsx
+++ b/front/src/views/resource/resource-manage/account/accountList/index.tsx
@@ -117,6 +117,7 @@ export default defineComponent({
               onClick={() => {
                 setAccountId('');
                 resourceAccountStore.setCurrentVendor(null);
+                resourceAccountStore.setCurrentAccountVendor(null);
               }}>
               <img src={allVendors} alt='全部账号' class={'vendor-icon'} />
               <div>全部账号</div>

--- a/front/src/views/resource/resource-manage/resource-manage.vue
+++ b/front/src/views/resource/resource-manage/resource-manage.vue
@@ -335,6 +335,10 @@ watch(
       } else {
         filter.value.rules[vendorRuleIdx].value = vendor;
       }
+      // 安全组列表下, 需要对 vendor = GCP 做额外的处理(GCP防火墙规则不支持vendor搜索条件)
+      if (activeTab.value === 'security' && vendor === VendorEnum.GCP) {
+        filter.value.rules = filter.value.rules.filter((e: any) => e.field !== 'vendor');
+      }
     } else {
       filter.value.rules = filter.value.rules.filter((e: any) => e.field !== 'vendor');
     }


### PR DESCRIPTION
1. 移除无用的响应式数据securityType
2. 增加新的状态currentAccountVendor, 替代resourceAccountStore.resourceAccount?.vendor的判断逻辑(由于网络请求造成的时间消耗, 会导致页面渲染不符合预期)
3. 完善tab显示与隐藏的逻辑判断, 以及处理GCP防火墙列表相关接口的参数

--story=116337643