### PR TITLE
fix(data,sql): 监听器增加拓展字段、SNI属性上移

### DIFF
--- a/cmd/data-service/service/cloud/load-balancer/create.go
+++ b/cmd/data-service/service/cloud/load-balancer/create.go
@@ -352,7 +352,6 @@ func (svc *lbSvc) BatchCreateTCloudUrlRule(cts *rest.Contexts) (any, error) {
 			Domain:             rule.Domain,
 			URL:                rule.URL,
 			Scheduler:          rule.Scheduler,
-			SniSwitch:          rule.SniSwitch,
 			SessionType:        rule.SessionType,
 			SessionExpire:      rule.SessionExpire,
 			Memo:               rule.Memo,

--- a/cmd/data-service/service/cloud/load-balancer/query.go
+++ b/cmd/data-service/service/cloud/load-balancer/query.go
@@ -264,6 +264,7 @@ func convTableToBaseListener(one *tablelb.LoadBalancerListenerTable) *corelb.Bas
 		DefaultDomain: one.DefaultDomain,
 		Zones:         one.Zones,
 		Memo:          one.Memo,
+		SniSwitch:     one.SniSwitch,
 		Revision: &core.Revision{
 			Creator:   one.Creator,
 			Reviser:   one.Reviser,

--- a/cmd/data-service/service/cloud/load-balancer/query.go
+++ b/cmd/data-service/service/cloud/load-balancer/query.go
@@ -342,7 +342,6 @@ func convTableToBaseTCloudLbURLRule(kt *kit.Kit, one *tablelb.TCloudLbUrlRuleTab
 		Domain:             one.Domain,
 		URL:                one.URL,
 		Scheduler:          one.Scheduler,
-		SniSwitch:          one.SniSwitch,
 		SessionType:        one.SessionType,
 		SessionExpire:      one.SessionExpire,
 		HealthCheck:        healthCheck,
@@ -455,6 +454,7 @@ func (svc *lbSvc) ListTargetGroup(cts *rest.Contexts) (interface{}, error) {
 	return &protocloud.TargetGroupListResult{Details: details}, nil
 }
 
+// GetTargetGroup ...
 func (svc *lbSvc) GetTargetGroup(cts *rest.Contexts) (any, error) {
 	vendor := enumor.Vendor(cts.PathParameter("vendor").String())
 	if err := vendor.Validate(); err != nil {
@@ -524,6 +524,7 @@ func convTableToBaseTargetGroup(kt *kit.Kit, one *tablelb.LoadBalancerTargetGrou
 	}, nil
 }
 
+// GetListener ...
 func (svc *lbSvc) GetListener(cts *rest.Contexts) (any, error) {
 	vendor := enumor.Vendor(cts.PathParameter("vendor").String())
 	if err := vendor.Validate(); err != nil {

--- a/cmd/data-service/service/cloud/load-balancer/update.go
+++ b/cmd/data-service/service/cloud/load-balancer/update.go
@@ -229,6 +229,7 @@ func (svc *lbSvc) UpdateTargetGroup(cts *rest.Contexts) (interface{}, error) {
 	return nil, nil
 }
 
+// BatchUpdateTCloudUrlRule ..
 func (svc *lbSvc) BatchUpdateTCloudUrlRule(cts *rest.Contexts) (any, error) {
 	req := new(dataproto.TCloudUrlRuleBatchUpdateReq)
 	if err := cts.DecodeInto(req); err != nil {
@@ -260,7 +261,6 @@ func (svc *lbSvc) BatchUpdateTCloudUrlRule(cts *rest.Contexts) (any, error) {
 				Scheduler:          rule.Scheduler,
 				SessionExpire:      rule.SessionExpire,
 				SessionType:        rule.SessionType,
-				SniSwitch:          rule.SniSwitch,
 				Memo:               rule.Memo,
 				Reviser:            cts.Kit.User,
 			}

--- a/pkg/api/core/cloud/load-balancer/load_balancer.go
+++ b/pkg/api/core/cloud/load-balancer/load_balancer.go
@@ -93,9 +93,23 @@ type BaseListener struct {
 	Port          int64    `json:"port"`
 	DefaultDomain string   `json:"default_domain"`
 	Zones         []string `json:"zones"`
+	// 腾讯云 CLB 的七层 HTTPS 监听器支持 SNI，即支持绑定多个证书，监听规则中的不同域名可使用不同证书。
+	// SNI关闭，证书在监听器上；SNI关闭，证书在对应规则上
+	SniSwitch int64 `json:"sni_switch"`
 
 	Memo           *string `json:"memo"`
 	*core.Revision `json:",inline"`
+}
+
+// Listener 监听器带拓展
+type Listener[T ListenerExtension] struct {
+	*BaseListener `json:",inline"`
+	Extension     *T
+}
+
+// ListenerExtension 监听器拓展
+type ListenerExtension interface {
+	TCloudListenerExtension
 }
 
 // BaseTCloudLbUrlRule define base tcloud lb url rule.
@@ -114,10 +128,7 @@ type BaseTCloudLbUrlRule struct {
 	Domain             string          `json:"domain"`
 	URL                string          `json:"url"`
 	Scheduler          string          `json:"scheduler"`
-	// 腾讯云 CLB 的七层 HTTPS 监听器支持 SNI，即支持绑定多个证书，监听规则中的不同域名可使用不同证书。
-	// 如在同一个 CLB 的HTTPS:443 监听器中，*.test.com使用证书1，将来自该域名的请求转发至一组服务器上；
-	// *.example.com使用证书2，将来自该域名的请求转发至另一组服务器上。
-	SniSwitch     int64                  `json:"sni_switch"`
+
 	SessionType   string                 `json:"session_type"`
 	SessionExpire int64                  `json:"session_expire"`
 	HealthCheck   *TCloudHealthCheckInfo `json:"health_check"`
@@ -125,53 +136,6 @@ type BaseTCloudLbUrlRule struct {
 
 	Memo           *string `json:"memo"`
 	*core.Revision `json:",inline"`
-}
-
-// TCloudHealthCheckInfo define health check.
-type TCloudHealthCheckInfo struct {
-	// 是否开启健康检查：1（开启）、0（关闭）
-	HealthSwitch *int64 `json:"health_switch,omitempty"`
-	// 健康检查的响应超时时间（仅适用于四层监听器），可选值：2~60，默认值：2，单位：秒。响应超时时间要小于检查间隔时间
-	TimeOut *int64 `json:"time_out,omitempty"`
-	// 健康检查探测间隔时间，默认值：5，IPv4 CLB实例的取值范围为：2-300，IPv6 CLB 实例的取值范围为：5-300。单位：秒
-	// 说明：部分老旧 IPv4 CLB实例的取值范围为：5-300
-	IntervalTime *int64 `json:"interval_time,omitempty"`
-	// 健康阈值，默认值：3，表示当连续探测三次健康则表示该转发正常，可选值：2~10，单位：次
-	HealthNum *int64 `json:"health_num,omitempty"`
-	// 不健康阈值，默认值：3，表示当连续探测三次不健康则表示该转发异常，可选值：2~10，单位：次。
-	UnHealthNum *int64 `json:"un_health_num,omitempty"`
-	// 健康检查状态码（仅适用于HTTP/HTTPS转发规则、TCP监听器的HTTP健康检查方式）。可选值：1~31，默认 31。
-	// 1 表示探测后返回值 1xx 代表健康，2 表示返回 2xx 代表健康，4 表示返回 3xx 代表健康，8 表示返回 4xx 代表健康，
-	// 16 表示返回 5xx 代表健康。若希望多种返回码都可代表健康，则将相应的值相加。
-	HttpCode *int64 `json:"http_code"`
-	// 自定义探测相关参数。健康检查端口，默认为后端服务的端口，除非您希望指定特定端口，否则建议留空。（仅适用于TCP/UDP监听器）
-	CheckPort *int64 `json:"check_port,omitempty"`
-	// 健康检查使用的协议。取值 TCP | HTTP | HTTPS | GRPC | PING | CUSTOM，UDP监听器支持PING/CUSTOM，
-	// TCP监听器支持TCP/HTTP/CUSTOM，TCP_SSL/QUIC监听器支持TCP/HTTP，HTTP规则支持HTTP/GRPC，HTTPS规则支持HTTP/HTTPS/GRPC
-	CheckType *string `json:"check_type,omitempty"`
-	// HTTP版本。健康检查协议CheckType的值取HTTP时，必传此字段，代表后端服务的HTTP版本：HTTP/1.0、HTTP/1.1；（仅适用于TCP监听器）
-	HttpVersion *string `json:"http_version,omitempty"`
-	// 健康检查路径（仅适用于HTTP/HTTPS转发规则、TCP监听器的HTTP健康检查方式）
-	HttpCheckPath *string `json:"http_check_path,omitempty"`
-	// 健康检查域名（仅适用于HTTP/HTTPS监听器和TCP监听器的HTTP健康检查方式。针对TCP监听器，当使用HTTP健康检查方式时，该参数为必填项）
-	HttpCheckDomain *string `json:"http_check_domain,omitempty"`
-	// 健康检查方法（仅适用于HTTP/HTTPS转发规则、TCP监听器的HTTP健康检查方式），默认值：HEAD，可选值HEAD或GET
-	HttpCheckMethod *string `json:"http_check_method,omitempty"`
-	// 健康检查源IP类型：0（使用LB的VIP作为源IP），1（使用100.64网段IP作为源IP），默认值：0
-	SourceIpType *int64 `json:"source_ip_type,omitempty"`
-	// 自定义探测相关参数。健康检查协议CheckType的值取CUSTOM时，必填此字段，代表健康检查的输入格式，可取值：HEX或TEXT；
-	// 取值为HEX时，SendContext和RecvContext的字符只能在0123456789ABCDEF中选取且长度必须是偶数位。（仅适用于TCP/UDP监听器）
-	ContextType *string `json:"context_type"`
-}
-
-// TCloudCertificateInfo 证书信息，不存储具体证书信息，只保存对应id
-type TCloudCertificateInfo struct {
-	// 认证类型，UNIDIRECTIONAL：单向认证，MUTUAL：双向认证
-	SSLMode string `json:"ssl_mode"`
-	// CA证书，认证RS侧用的证书，只需要公钥
-	CaCloudID *string `json:"ca_cloud_id,omitempty"`
-	// 客户端证书，客户端向CLB发起请求时认证CLB来源是否可靠的证书。可以配置两个不同的加密类型的证书，
-	ClientCloudIDs []string `json:"client_cloud_ids,omitempty"`
 }
 
 // BaseClbTarget define base clb target.

--- a/pkg/api/core/cloud/load-balancer/tcloud.go
+++ b/pkg/api/core/cloud/load-balancer/tcloud.go
@@ -133,3 +133,55 @@ func (ip *SnatIp) String() string {
 // TCloudTargetGroupExtension tcloud target group extension.
 type TCloudTargetGroupExtension struct {
 }
+
+// TCloudHealthCheckInfo define health check.
+type TCloudHealthCheckInfo struct {
+	// 是否开启健康检查：1（开启）、0（关闭）
+	HealthSwitch *int64 `json:"health_switch,omitempty"`
+	// 健康检查的响应超时时间（仅适用于四层监听器），可选值：2~60，默认值：2，单位：秒。响应超时时间要小于检查间隔时间
+	TimeOut *int64 `json:"time_out,omitempty"`
+	// 健康检查探测间隔时间，默认值：5，IPv4 CLB实例的取值范围为：2-300，IPv6 CLB 实例的取值范围为：5-300。单位：秒
+	// 说明：部分老旧 IPv4 CLB实例的取值范围为：5-300
+	IntervalTime *int64 `json:"interval_time,omitempty"`
+	// 健康阈值，默认值：3，表示当连续探测三次健康则表示该转发正常，可选值：2~10，单位：次
+	HealthNum *int64 `json:"health_num,omitempty"`
+	// 不健康阈值，默认值：3，表示当连续探测三次不健康则表示该转发异常，可选值：2~10，单位：次。
+	UnHealthNum *int64 `json:"un_health_num,omitempty"`
+	// 健康检查状态码（仅适用于HTTP/HTTPS转发规则、TCP监听器的HTTP健康检查方式）。可选值：1~31，默认 31。
+	// 1 表示探测后返回值 1xx 代表健康，2 表示返回 2xx 代表健康，4 表示返回 3xx 代表健康，8 表示返回 4xx 代表健康，
+	// 16 表示返回 5xx 代表健康。若希望多种返回码都可代表健康，则将相应的值相加。
+	HttpCode *int64 `json:"http_code"`
+	// 自定义探测相关参数。健康检查端口，默认为后端服务的端口，除非您希望指定特定端口，否则建议留空。（仅适用于TCP/UDP监听器）
+	CheckPort *int64 `json:"check_port,omitempty"`
+	// 健康检查使用的协议。取值 TCP | HTTP | HTTPS | GRPC | PING | CUSTOM，UDP监听器支持PING/CUSTOM，
+	// TCP监听器支持TCP/HTTP/CUSTOM，TCP_SSL/QUIC监听器支持TCP/HTTP，HTTP规则支持HTTP/GRPC，HTTPS规则支持HTTP/HTTPS/GRPC
+	CheckType *string `json:"check_type,omitempty"`
+	// HTTP版本。健康检查协议CheckType的值取HTTP时，必传此字段，代表后端服务的HTTP版本：HTTP/1.0、HTTP/1.1；（仅适用于TCP监听器）
+	HttpVersion *string `json:"http_version,omitempty"`
+	// 健康检查路径（仅适用于HTTP/HTTPS转发规则、TCP监听器的HTTP健康检查方式）
+	HttpCheckPath *string `json:"http_check_path,omitempty"`
+	// 健康检查域名（仅适用于HTTP/HTTPS监听器和TCP监听器的HTTP健康检查方式。针对TCP监听器，当使用HTTP健康检查方式时，该参数为必填项）
+	HttpCheckDomain *string `json:"http_check_domain,omitempty"`
+	// 健康检查方法（仅适用于HTTP/HTTPS转发规则、TCP监听器的HTTP健康检查方式），默认值：HEAD，可选值HEAD或GET
+	HttpCheckMethod *string `json:"http_check_method,omitempty"`
+	// 健康检查源IP类型：0（使用LB的VIP作为源IP），1（使用100.64网段IP作为源IP），默认值：0
+	SourceIpType *int64 `json:"source_ip_type,omitempty"`
+	// 自定义探测相关参数。健康检查协议CheckType的值取CUSTOM时，必填此字段，代表健康检查的输入格式，可取值：HEX或TEXT；
+	// 取值为HEX时，SendContext和RecvContext的字符只能在0123456789ABCDEF中选取且长度必须是偶数位。（仅适用于TCP/UDP监听器）
+	ContextType *string `json:"context_type"`
+}
+
+// TCloudCertificateInfo 证书信息，不存储具体证书信息，只保存对应id
+type TCloudCertificateInfo struct {
+	// 认证类型，UNIDIRECTIONAL：单向认证，MUTUAL：双向认证
+	SSLMode string `json:"ssl_mode"`
+	// CA证书，认证RS侧用的证书，只需要公钥
+	CaCloudID *string `json:"ca_cloud_id,omitempty"`
+	// 客户端证书，客户端向CLB发起请求时认证CLB来源是否可靠的证书。可以配置两个不同的加密类型的证书，
+	ClientCloudIDs []string `json:"client_cloud_ids,omitempty"`
+}
+
+// TCloudListenerExtension 腾讯云监听器拓展
+type TCloudListenerExtension struct {
+	Certificate *TCloudCertificateInfo `json:"certificate"`
+}

--- a/pkg/api/data-service/cloud/load_balancer.go
+++ b/pkg/api/data-service/cloud/load_balancer.go
@@ -38,6 +38,7 @@ type LoadBalancerBatchCreateReq[Extension corelb.Extension] struct {
 	Lbs []LbBatchCreate[Extension] `json:"lbs" validate:"required,min=1"`
 }
 
+// TCloudCLBCreateReq ...
 type TCloudCLBCreateReq = LoadBalancerBatchCreateReq[corelb.TCloudClbExtension]
 
 // LbBatchCreate define load balancer batch create.
@@ -122,6 +123,7 @@ func (req *LbExtBatchUpdateReq[T]) Validate() error {
 	return validator.Validate.Struct(req)
 }
 
+// TCloudClbBatchUpdateReq ...
 type TCloudClbBatchUpdateReq = LbExtBatchUpdateReq[corelb.TCloudClbExtension]
 
 // ClbBizBatchUpdateReq 批量更新业务id
@@ -210,7 +212,6 @@ type TCloudUrlRuleCreate struct {
 	Domain             string                        `json:"domain"`
 	URL                string                        `json:"url"`
 	Scheduler          string                        `json:"scheduler"`
-	SniSwitch          int64                         `json:"sni_switch"`
 	SessionType        string                        `json:"session_type"`
 	SessionExpire      int64                         `json:"session_expire"`
 	HealthCheck        *corelb.TCloudHealthCheckInfo `json:"health_check" validate:"required"`

--- a/pkg/dal/table/cloud/load-balancer/load_balancer_listener.go
+++ b/pkg/dal/table/cloud/load-balancer/load_balancer_listener.go
@@ -48,6 +48,8 @@ var LoadBalancerListenerColumnsDescriptor = utils.ColumnDescriptors{
 	{Column: "default_domain", NamedC: "default_domain", Type: enumor.String},
 	{Column: "zones", NamedC: "zones", Type: enumor.Json},
 	{Column: "memo", NamedC: "memo", Type: enumor.String},
+	{Column: "sni_switch", NamedC: "sni_switch", Type: enumor.Numeric},
+	{Column: "extension", NamedC: "extension", Type: enumor.Json},
 
 	{Column: "creator", NamedC: "creator", Type: enumor.String},
 	{Column: "reviser", NamedC: "reviser", Type: enumor.String},
@@ -71,6 +73,8 @@ type LoadBalancerListenerTable struct {
 	DefaultDomain string            `db:"default_domain" json:"default_domain"`
 	Zones         types.StringArray `db:"zones" json:"zones"`
 	Memo          *string           `db:"memo" json:"memo"`
+	SniSwitch     int64             `db:"sni_switch" json:"sni_switch"`
+	Extension     types.JsonField   `db:"extension" json:"extension"`
 
 	Creator   string     `db:"creator" validate:"lte=64" json:"creator"`
 	Reviser   string     `db:"reviser" validate:"lte=64" json:"reviser"`

--- a/pkg/dal/table/cloud/load-balancer/tcloud_lb_url_rule.go
+++ b/pkg/dal/table/cloud/load-balancer/tcloud_lb_url_rule.go
@@ -48,7 +48,6 @@ var TCloudClbUrlRuleColumnsDescriptor = utils.ColumnDescriptors{
 	{Column: "domain", NamedC: "domain", Type: enumor.String},
 	{Column: "url", NamedC: "url", Type: enumor.String},
 	{Column: "scheduler", NamedC: "scheduler", Type: enumor.String},
-	{Column: "sni_switch", NamedC: "sni_switch", Type: enumor.Numeric},
 	{Column: "session_type", NamedC: "session_type", Type: enumor.String},
 	{Column: "session_expire", NamedC: "session_expire", Type: enumor.Numeric},
 	{Column: "health_check", NamedC: "health_check", Type: enumor.Json},
@@ -77,7 +76,6 @@ type TCloudLbUrlRuleTable struct {
 	Domain             string          `db:"domain" json:"domain"`
 	URL                string          `db:"url" json:"url"`
 	Scheduler          string          `db:"scheduler" json:"scheduler"`
-	SniSwitch          int64           `db:"sni_switch" json:"sni_switch"`
 	SessionType        string          `db:"session_type" json:"session_type"`
 	SessionExpire      int64           `db:"session_expire" json:"session_expire"`
 	HealthCheck        types.JsonField `db:"health_check" json:"health_check"`

--- a/scripts/sql/9999_tcloud_clb.sql
+++ b/scripts/sql/9999_tcloud_clb.sql
@@ -112,6 +112,8 @@ create table `load_balancer_listener`
     `port`           bigint       not null,
     `default_domain` varchar(255)          default null,
     `zones`          json,
+    `sni_switch`     bigint                default 0,
+    `certificate`    json                  default null,
     `memo`           varchar(255)          default '',
 
     `creator`        varchar(64)  not null,
@@ -143,7 +145,6 @@ create table `tcloud_lb_url_rule`
     `domain`                varchar(255)          default '',
     `url`                   varchar(255)          default '',
     `scheduler`             varchar(64)  not null,
-    `sni_switch`            bigint                default 0,
     `session_type`          varchar(64)           default '',
     `session_expire`        bigint                default 0,
     `health_check`          json                  default null,


### PR DESCRIPTION
https 非SNI监听器的证书属性在监听器上，原来证书只有在规则上有，在无规则的情况下无法存储对应监听器证书信息

--story=116629969 HTTPS监听器证书、SNI字段修复