### PR TITLE
fix(hc/sync): 腾讯云负载均衡Extension字段修改为指针类型、增加计费字段，屏蔽4层操作

### DIFF
--- a/cmd/hc-service/logics/res-sync/tcloud/load_balancer.go
+++ b/cmd/hc-service/logics/res-sync/tcloud/load_balancer.go
@@ -37,6 +37,7 @@ import (
 	"hcm/pkg/dal/dao/tools"
 	"hcm/pkg/kit"
 	"hcm/pkg/logs"
+	"hcm/pkg/tools/assert"
 	cvt "hcm/pkg/tools/converter"
 	"hcm/pkg/tools/slice"
 
@@ -406,21 +407,21 @@ func convCloudToDBCreate(cloud typeslb.TCloudClb, accountID string, region strin
 
 func convertTCloudExtension(cloud typeslb.TCloudClb) *corelb.TCloudClbExtension {
 	ext := &corelb.TCloudClbExtension{
-		SlaType:                  cvt.PtrToVal(cloud.SlaType),
-		VipIsp:                   cvt.PtrToVal(cloud.VipIsp),
-		LoadBalancerPassToTarget: cvt.PtrToVal(cloud.LoadBalancerPassToTarget),
-		IPv6Mode:                 cvt.PtrToVal(cloud.IPv6Mode),
-		Snat:                     cvt.PtrToVal(cloud.Snat),
-		SnatPro:                  cvt.PtrToVal(cloud.SnatPro),
-		MixIpTarget:              cvt.PtrToVal(cloud.MixIpTarget),
-		ChargeType:               cvt.PtrToVal(cloud.ChargeType),
+		SlaType:                  cloud.SlaType,
+		VipIsp:                   cloud.VipIsp,
+		LoadBalancerPassToTarget: cloud.LoadBalancerPassToTarget,
+		IPv6Mode:                 cloud.IPv6Mode,
+		Snat:                     cloud.Snat,
+		SnatPro:                  cloud.SnatPro,
+		MixIpTarget:              cloud.MixIpTarget,
+		ChargeType:               cloud.ChargeType,
 		// 该接口无法获取下列字段
 		BandwidthPackageId: nil,
 	}
 	if cloud.NetworkAttributes != nil {
-		ext.InternetMaxBandwidthOut = cvt.PtrToVal(cloud.NetworkAttributes.InternetMaxBandwidthOut)
-		ext.InternetChargeType = cvt.PtrToVal(cloud.NetworkAttributes.InternetChargeType)
-		ext.BandwidthpkgSubType = cvt.PtrToVal(cloud.NetworkAttributes.BandwidthpkgSubType)
+		ext.InternetMaxBandwidthOut = cloud.NetworkAttributes.InternetMaxBandwidthOut
+		ext.InternetChargeType = cloud.NetworkAttributes.InternetChargeType
+		ext.BandwidthpkgSubType = cloud.NetworkAttributes.BandwidthpkgSubType
 	}
 	if cloud.SnatIps != nil {
 		ipList := make([]corelb.SnatIp, 0, len(cloud.SnatIps))
@@ -433,13 +434,13 @@ func convertTCloudExtension(cloud typeslb.TCloudClb) *corelb.TCloudClbExtension 
 		ext.SnatIps = ipList
 	}
 
+	flagMap := make(map[string]bool)
 	// 没有碰到的则默认是false
 	for _, flag := range cloud.AttributeFlags {
-		switch cvt.PtrToVal(flag) {
-		case constant.TCLBDeleteProtect:
-			ext.DeleteProtect = true
-		}
+		flagMap[cvt.PtrToVal(flag)] = true
 	}
+	// 逐个赋值flag
+	ext.DeleteProtect = cvt.ValToPtr(flagMap[constant.TCLBDeleteProtect])
 
 	return ext
 }
@@ -458,20 +459,20 @@ func convCloudToDBUpdate(id string,
 		CloudExpiredTime: cvt.PtrToVal(cloud.ExpireTime),
 
 		Extension: &corelb.TCloudClbExtension{
-			SlaType:                  cvt.PtrToVal(cloud.SlaType),
-			VipIsp:                   cvt.PtrToVal(cloud.VipIsp),
-			LoadBalancerPassToTarget: cvt.PtrToVal(cloud.LoadBalancerPassToTarget),
-			ChargeType:               cvt.PtrToVal(cloud.ChargeType),
+			SlaType:                  cloud.SlaType,
+			VipIsp:                   cloud.VipIsp,
+			LoadBalancerPassToTarget: cloud.LoadBalancerPassToTarget,
+			ChargeType:               cloud.ChargeType,
 
-			IPv6Mode: cvt.PtrToVal(cloud.IPv6Mode),
-			Snat:     cvt.PtrToVal(cloud.Snat),
-			SnatPro:  cvt.PtrToVal(cloud.SnatPro),
+			IPv6Mode: cloud.IPv6Mode,
+			Snat:     cloud.Snat,
+			SnatPro:  cloud.SnatPro,
 		},
 	}
 	if cloud.NetworkAttributes != nil {
-		lb.Extension.InternetMaxBandwidthOut = cvt.PtrToVal(cloud.NetworkAttributes.InternetMaxBandwidthOut)
-		lb.Extension.InternetChargeType = cvt.PtrToVal(cloud.NetworkAttributes.InternetChargeType)
-		lb.Extension.BandwidthpkgSubType = cvt.PtrToVal(cloud.NetworkAttributes.BandwidthpkgSubType)
+		lb.Extension.InternetMaxBandwidthOut = cloud.NetworkAttributes.InternetMaxBandwidthOut
+		lb.Extension.InternetChargeType = cloud.NetworkAttributes.InternetChargeType
+		lb.Extension.BandwidthpkgSubType = cloud.NetworkAttributes.BandwidthpkgSubType
 	}
 	if cloud.SnatIps != nil {
 		ipList := make([]corelb.SnatIp, 0, len(cloud.SnatIps))
@@ -495,17 +496,18 @@ func convCloudToDBUpdate(id string,
 	if ipv6 := cvt.PtrToVal(cloud.AddressIPv6); len(ipv6) > 0 {
 		lb.PublicIPv6Addresses = []string{ipv6}
 	}
+
 	// AttributeFlags
+	flagMap := make(map[string]bool)
 	// 没有碰到的则默认是false
 	for _, flag := range cloud.AttributeFlags {
-		switch cvt.PtrToVal(flag) {
-		case constant.TCLBDeleteProtect:
-			lb.Extension.DeleteProtect = true
-		}
+		flagMap[cvt.PtrToVal(flag)] = true
 	}
+	// 逐个赋值flag
+	lb.Extension.DeleteProtect = cvt.ValToPtr(flagMap[constant.TCLBDeleteProtect])
 
 	if cloud.Egress != nil {
-		lb.Extension.Egress = cvt.PtrToVal(cloud.Egress)
+		lb.Extension.Egress = cloud.Egress
 	}
 	return &lb
 }
@@ -556,7 +558,9 @@ func isLBChange(cloud typeslb.TCloudClb, db corelb.TCloudLoadBalancer) bool {
 			return true
 		}
 	}
-	if ipv6 := cvt.PtrToVal(cloud.AddressIPv6); len(db.PublicIPv6Addresses) == 0 || db.PublicIPv6Addresses[0] != ipv6 {
+	ipv6 := cvt.PtrToVal(cloud.AddressIPv6)
+	if len(db.PublicIPv6Addresses) == 0 && len(ipv6) != 0 ||
+		len(db.PublicIPv6Addresses) > 0 && db.PublicIPv6Addresses[0] != ipv6 {
 		return true
 	}
 
@@ -569,40 +573,41 @@ func isLBExtensionChange(cloud typeslb.TCloudClb, db corelb.TCloudLoadBalancer) 
 	}
 
 	if cloud.NetworkAttributes != nil {
-		if db.Extension.InternetMaxBandwidthOut != cvt.PtrToVal(cloud.NetworkAttributes.InternetMaxBandwidthOut) {
+		if !assert.IsPtrInt64Equal(db.Extension.InternetMaxBandwidthOut,
+			cloud.NetworkAttributes.InternetMaxBandwidthOut) {
 			return true
 		}
-		if db.Extension.InternetChargeType != cvt.PtrToVal(cloud.NetworkAttributes.InternetChargeType) {
+		if !assert.IsPtrStringEqual(db.Extension.InternetChargeType, cloud.NetworkAttributes.InternetChargeType) {
 			return true
 		}
-		if db.Extension.BandwidthpkgSubType != cvt.PtrToVal(cloud.NetworkAttributes.BandwidthpkgSubType) {
+		if !assert.IsPtrStringEqual(db.Extension.BandwidthpkgSubType, cloud.NetworkAttributes.BandwidthpkgSubType) {
 			return true
 		}
 	}
 
-	if db.Extension.SlaType != cvt.PtrToVal(cloud.SlaType) {
+	if !assert.IsPtrStringEqual(db.Extension.SlaType, cloud.SlaType) {
 		return true
 	}
-	if db.Extension.VipIsp != cvt.PtrToVal(cloud.VipIsp) {
+	if !assert.IsPtrStringEqual(db.Extension.VipIsp, cloud.VipIsp) {
 		return true
 	}
 
-	if db.Extension.LoadBalancerPassToTarget != cvt.PtrToVal(cloud.LoadBalancerPassToTarget) {
+	if !assert.IsPtrBoolEqual(db.Extension.LoadBalancerPassToTarget, cloud.LoadBalancerPassToTarget) {
 		return true
 	}
-	if db.Extension.IPv6Mode != cvt.PtrToVal(cloud.IPv6Mode) {
+	if !assert.IsPtrStringEqual(db.Extension.IPv6Mode, cloud.IPv6Mode) {
 		return true
 	}
-	if db.Extension.Egress != cvt.PtrToVal(cloud.Egress) {
+	if !assert.IsPtrStringEqual(db.Extension.Egress, cloud.Egress) {
 		return true
 	}
-	if db.Extension.Snat != cvt.PtrToVal(cloud.Snat) {
+	if !assert.IsPtrBoolEqual(db.Extension.Snat, cloud.Snat) {
 		return true
 	}
-	if db.Extension.SnatPro != cvt.PtrToVal(cloud.SnatPro) {
+	if !assert.IsPtrBoolEqual(db.Extension.SnatPro, cloud.SnatPro) {
 		return true
 	}
-	if db.Extension.ChargeType != cvt.PtrToVal(cloud.ChargeType) {
+	if !assert.IsPtrStringEqual(db.Extension.ChargeType, cloud.ChargeType) {
 		return true
 	}
 	// SnatIP列表对比
@@ -611,13 +616,13 @@ func isLBExtensionChange(cloud typeslb.TCloudClb, db corelb.TCloudLoadBalancer) 
 	}
 
 	// 云上AttributeFlags 转map
-	attrs := make(map[string]struct{}, len(cloud.AttributeFlags))
+	attrs := make(map[string]bool, len(cloud.AttributeFlags))
 	for _, flag := range cloud.AttributeFlags {
-		attrs[cvt.PtrToVal(flag)] = struct{}{}
+		attrs[cvt.PtrToVal(flag)] = true
 	}
 
 	// 逐个判断每种类型
-	if _, deleteProtect := attrs[constant.TCLBDeleteProtect]; deleteProtect != db.Extension.DeleteProtect {
+	if attrs[constant.TCLBDeleteProtect] != cvt.PtrToVal(db.Extension.DeleteProtect) {
 		return true
 	}
 

--- a/cmd/hc-service/logics/res-sync/tcloud/load_balancer.go
+++ b/cmd/hc-service/logics/res-sync/tcloud/load_balancer.go
@@ -413,6 +413,7 @@ func convertTCloudExtension(cloud typeslb.TCloudClb) *corelb.TCloudClbExtension 
 		Snat:                     cvt.PtrToVal(cloud.Snat),
 		SnatPro:                  cvt.PtrToVal(cloud.SnatPro),
 		MixIpTarget:              cvt.PtrToVal(cloud.MixIpTarget),
+		ChargeType:               cvt.PtrToVal(cloud.ChargeType),
 		// 该接口无法获取下列字段
 		BandwidthPackageId: nil,
 	}
@@ -460,6 +461,7 @@ func convCloudToDBUpdate(id string,
 			SlaType:                  cvt.PtrToVal(cloud.SlaType),
 			VipIsp:                   cvt.PtrToVal(cloud.VipIsp),
 			LoadBalancerPassToTarget: cvt.PtrToVal(cloud.LoadBalancerPassToTarget),
+			ChargeType:               cvt.PtrToVal(cloud.ChargeType),
 
 			IPv6Mode: cvt.PtrToVal(cloud.IPv6Mode),
 			Snat:     cvt.PtrToVal(cloud.Snat),
@@ -600,7 +602,9 @@ func isLBExtensionChange(cloud typeslb.TCloudClb, db corelb.TCloudLoadBalancer) 
 	if db.Extension.SnatPro != cvt.PtrToVal(cloud.SnatPro) {
 		return true
 	}
-
+	if db.Extension.ChargeType != cvt.PtrToVal(cloud.ChargeType) {
+		return true
+	}
 	// SnatIP列表对比
 	if isSnatIPChange(cloud, db) {
 		return true

--- a/cmd/hc-service/logics/res-sync/tcloud/load_balancer_listener.go
+++ b/cmd/hc-service/logics/res-sync/tcloud/load_balancer_listener.go
@@ -336,56 +336,56 @@ func isHealthCheckChange(cloud *tclb.HealthCheck, db *corelb.TCloudHealthCheckIn
 		// 云上和本地都为空 则是未变化，否则需要更新本地
 		return !(cloud == nil && db == nil)
 	}
-	if assert.IsPtrInt64Equal(cloud.HealthSwitch, db.HealthSwitch) {
+	if !assert.IsPtrInt64Equal(cloud.HealthSwitch, db.HealthSwitch) {
 		return true
 	}
-	if assert.IsPtrInt64Equal(cloud.TimeOut, db.TimeOut) {
+	if !assert.IsPtrInt64Equal(cloud.TimeOut, db.TimeOut) {
 		return true
 	}
-	if assert.IsPtrInt64Equal(cloud.IntervalTime, db.IntervalTime) {
+	if !assert.IsPtrInt64Equal(cloud.IntervalTime, db.IntervalTime) {
 		return true
 	}
-	if assert.IsPtrInt64Equal(cloud.HealthNum, db.HealthNum) {
+	if !assert.IsPtrInt64Equal(cloud.HealthNum, db.HealthNum) {
 		return true
 	}
-	if assert.IsPtrInt64Equal(cloud.UnHealthNum, db.UnHealthNum) {
+	if !assert.IsPtrInt64Equal(cloud.UnHealthNum, db.UnHealthNum) {
 		return true
 	}
-	if assert.IsPtrInt64Equal(cloud.HttpCode, db.HttpCode) {
+	if !assert.IsPtrInt64Equal(cloud.HttpCode, db.HttpCode) {
 		return true
 	}
-	if assert.IsPtrStringEqual(cloud.HttpCheckPath, db.HttpCheckPath) {
+	if !assert.IsPtrStringEqual(cloud.HttpCheckPath, db.HttpCheckPath) {
 		return true
 	}
-	if assert.IsPtrStringEqual(cloud.HttpCheckDomain, db.HttpCheckDomain) {
+	if !assert.IsPtrStringEqual(cloud.HttpCheckDomain, db.HttpCheckDomain) {
 		return true
 	}
-	if assert.IsPtrStringEqual(cloud.HttpCheckMethod, db.HttpCheckMethod) {
+	if !assert.IsPtrStringEqual(cloud.HttpCheckMethod, db.HttpCheckMethod) {
 		return true
 	}
-	if assert.IsPtrInt64Equal(cloud.CheckPort, db.CheckPort) {
+	if !assert.IsPtrInt64Equal(cloud.CheckPort, db.CheckPort) {
 		return true
 	}
-	if assert.IsPtrStringEqual(cloud.ContextType, db.ContextType) {
+	if !assert.IsPtrStringEqual(cloud.ContextType, db.ContextType) {
 		return true
 	}
-	if assert.IsPtrStringEqual(cloud.SendContext, db.SendContext) {
+	if !assert.IsPtrStringEqual(cloud.SendContext, db.SendContext) {
 		return true
 	}
-	if assert.IsPtrStringEqual(cloud.RecvContext, db.RecvContext) {
+	if !assert.IsPtrStringEqual(cloud.RecvContext, db.RecvContext) {
 		return true
 	}
-	if assert.IsPtrStringEqual(cloud.CheckType, db.CheckType) {
+	if !assert.IsPtrStringEqual(cloud.CheckType, db.CheckType) {
 		return true
 	}
-	if assert.IsPtrStringEqual(cloud.HttpVersion, db.HttpVersion) {
+	if !assert.IsPtrStringEqual(cloud.HttpVersion, db.HttpVersion) {
 		return true
 	}
 
-	if assert.IsPtrInt64Equal(cloud.SourceIpType, db.SourceIpType) {
+	if !assert.IsPtrInt64Equal(cloud.SourceIpType, db.SourceIpType) {
 		return true
 	}
-	if assert.IsPtrStringEqual(cloud.ExtendedCode, db.ExtendedCode) {
+	if !assert.IsPtrStringEqual(cloud.ExtendedCode, db.ExtendedCode) {
 		return true
 	}
 

--- a/cmd/hc-service/service/load-balancer/tcloud_rule.go
+++ b/cmd/hc-service/service/load-balancer/tcloud_rule.go
@@ -307,6 +307,9 @@ func (svc *clbSvc) TCloudBatchDeleteUrlRuleByDomain(cts *rest.Contexts) (any, er
 			err, req.Domains, cts.Kit.Rid)
 		return nil, err
 	}
+	if !listener.Protocol.IsLayer7Protocol() {
+		return nil, errf.Newf(errf.InvalidParameter, "unsupported listner protocol type: %s", listener.Protocol)
+	}
 	ruleOption := typelb.TCloudDeleteRuleOption{
 		Region:                 lb.Region,
 		LoadBalancerId:         lb.CloudID,

--- a/pkg/api/core/cloud/load-balancer/tcloud.go
+++ b/pkg/api/core/cloud/load-balancer/tcloud.go
@@ -41,7 +41,10 @@ type TCloudClbExtension struct {
 		若需要创建共享型实例，则无需填写此参数。
 	*/
 	SlaType string `json:"sla_type,omitempty"`
-
+	/*
+		ChargeType 负载均衡实例的计费类型，PREPAID：包年包月，POSTPAID_BY_HOUR：按量计费
+	*/
+	ChargeType string `json:"charge_type"`
 	/*
 		VipIsp 仅适用于公网负载均衡。
 		目前仅广州、上海、南京、济南、杭州、福州、北京、石家庄、武汉、长沙、成都、重庆地域支持静态单线 IP 线路类型，

--- a/pkg/api/core/cloud/load-balancer/tcloud.go
+++ b/pkg/api/core/cloud/load-balancer/tcloud.go
@@ -40,25 +40,25 @@ type TCloudClbExtension struct {
 		clb.c4.xlarge：超强型4规格
 		若需要创建共享型实例，则无需填写此参数。
 	*/
-	SlaType string `json:"sla_type,omitempty"`
+	SlaType *string `json:"sla_type,omitempty"`
 	/*
 		ChargeType 负载均衡实例的计费类型，PREPAID：包年包月，POSTPAID_BY_HOUR：按量计费
 	*/
-	ChargeType string `json:"charge_type"`
+	ChargeType *string `json:"charge_type,omitempty"`
 	/*
 		VipIsp 仅适用于公网负载均衡。
 		目前仅广州、上海、南京、济南、杭州、福州、北京、石家庄、武汉、长沙、成都、重庆地域支持静态单线 IP 线路类型，
 		可选择中国移动（CMCC）、中国联通（CUCC）或中国电信（CTCC）的运营商类型，网络计费模式只能使用按带宽包计费(BANDWIDTH_PACKAGE)。
 		如果不指定本参数，则默认使用BGP。可通过 DescribeResources 接口查询一个地域所支持的Isp。
 	*/
-	VipIsp string `json:"vip_isp,omitempty"`
+	VipIsp *string `json:"vip_isp,omitempty"`
 
 	/*
 		LoadBalancerPassToTarget Target是否放通来自CLB的流量。
 		开启放通（true）：只验证CLB上的安全组；
 		不开启放通（false）：需同时验证CLB和后端实例上的安全组。
 	*/
-	LoadBalancerPassToTarget bool `json:"load_balancer_pass_to_target,omitempty"`
+	LoadBalancerPassToTarget *bool `json:"load_balancer_pass_to_target,omitempty"`
 
 	/*
 		InternetMaxBandwidthOut 最大出带宽，单位Mbps，仅对公网属性的共享型、性能容量型和独占型 CLB 实例、以及内网属性的性能容量型 CLB 实例生效。
@@ -68,7 +68,8 @@ type TCloudClbExtension struct {
 		注意：此字段可能返回 null，表示取不到有效值。
 		示例值：1
 	*/
-	InternetMaxBandwidthOut int64 `json:"internet_max_bandwidth_out,omitempty"`
+	InternetMaxBandwidthOut *int64 `json:"internet_max_bandwidth_out,omitempty"`
+
 	/*
 		InternetChargeType
 		TRAFFIC_POSTPAID_BY_HOUR 按流量按小时后计费 ;
@@ -77,12 +78,12 @@ type TCloudClbExtension struct {
 		注意：此字段可能返回 null，表示取不到有效值。
 		示例值：BANDWIDTH_POSTPAID_BY_HOUR
 	*/
-	InternetChargeType string `json:"internet_charge_type,omitempty"`
+	InternetChargeType *string `json:"internet_charge_type,omitempty"`
 	/*
 		BandwidthpkgSubType 带宽包的类型，如SINGLEISP（单线）、BGP（多线）。
 		注意：此字段可能返回 null，表示取不到有效值。
 	*/
-	BandwidthpkgSubType string `json:"bandwidthpkg_sub_type,omitempty"`
+	BandwidthpkgSubType *string `json:"bandwidthpkg_sub_type,omitempty"`
 
 	/*
 		BandwidthPackageId 带宽包ID，
@@ -93,31 +94,31 @@ type TCloudClbExtension struct {
 	BandwidthPackageId *string `json:"bandwidth_package_id,omitempty"`
 
 	// IP地址版本为ipv6时此字段有意义， IPv6Nat64 | IPv6FullChain
-	IPv6Mode string `json:"ipv6_mode,omitempty"`
+	IPv6Mode *string `json:"ipv6_mode,omitempty"`
 
 	// 在 2016 年 12 月份之前的传统型内网负载均衡都是开启了 snat 的。
-	Snat bool `json:"snat,omitempty" `
+	Snat *bool `json:"snat,omitempty" `
 
 	// 是否开启SnatPro。
-	SnatPro bool `json:"snat_pro,omitempty"`
+	SnatPro *bool `json:"snat_pro,omitempty"`
 
 	// 开启SnatPro负载均衡后，SnatIp列表。
 	SnatIps []SnatIp `json:"snat_ips,omitempty"`
 
 	// 删除保护
-	DeleteProtect bool `json:"delete_protect,omitempty"`
+	DeleteProtect *bool `json:"delete_protect,omitempty"`
 
 	// 网络出口
-	Egress string `json:"egress,omitempty"`
+	Egress *string `json:"egress,omitempty"`
 
 	// 双栈混绑 开启IPv6FullChain负载均衡7层监听器支持混绑IPv4/IPv6目标功能。
-	MixIpTarget bool `json:"mix_ip_target,omitempty"`
+	MixIpTarget *bool `json:"mix_ip_target,omitempty"`
 }
 
 // SnatIp ...
 type SnatIp struct {
 	// 私有网络子网的唯一性id，如subnet-12345678
-	SubnetId *string `json:"subnet_id" `
+	SubnetId *string `json:"subnet_id"`
 
 	// IP地址，如192.168.0.1
 	Ip *string `json:"ip"`


### PR DESCRIPTION
- fix(hc/sync): 腾讯云负载均衡Extension字段修改为指针类型

> 改为指针字段后配合 `json:"omitempty"`tag，实现对未修改字段的忽略以及修改为零值的支持

- feat(hc/sync): 腾讯云负载均衡支持计费模式字段
- feat(cloud): 屏蔽4层监听器的规则操作

--story=116444966 CLB 同步