### PR TITLE
feat(async/task): 支持 task 重试和 flow 取消

### DIFF
--- a/cmd/task-server/service/controller/controller.go
+++ b/cmd/task-server/service/controller/controller.go
@@ -1,0 +1,125 @@
+/*
+ *
+ * TencentBlueKing is pleased to support the open source community by making
+ * 蓝鲸智云 - 混合云管理平台 (BlueKing - Hybrid Cloud Management System) available.
+ * Copyright (C) 2024 THL A29 Limited,
+ * a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * We undertake not to change the open source license (MIT license) applicable
+ *
+ * to the current version of the project delivered to anyone in the future.
+ */
+
+// Package controller 对异步任务的控制
+package controller
+
+import (
+	"hcm/cmd/task-server/service/capability"
+	"hcm/pkg/async/consumer"
+	"hcm/pkg/async/producer"
+	"hcm/pkg/client"
+	"hcm/pkg/criteria/errf"
+	"hcm/pkg/logs"
+	"hcm/pkg/rest"
+	"hcm/pkg/tools/retry"
+)
+
+// Init initial the async service
+func Init(cap *capability.Capability) {
+	svc := &service{
+		cs:  cap.ApiClient,
+		pro: cap.Async.GetProducer(),
+		csm: cap.Async.GetConsumer(),
+	}
+
+	h := rest.NewHandler()
+
+	h.Add("UpdateCustomFlowState", "PATCH", "/custom_flows/state/update", svc.UpdateCustomFlowState)
+	h.Add("RetryFlowTask", "PATCH", "/flows/{flow_id}/tasks/{task_id}/retry", svc.RetryFlowTask)
+	h.Add("CancelFlow", "POST", "/flows/{flow_id}/cancel", svc.CancelFlow)
+	h.Add("CloneFlow", "POST", "/flows/{flow_id}/clone", svc.CloneFlow)
+
+	h.Load(cap.WebService)
+}
+
+type service struct {
+	cs  *client.ClientSet
+	pro producer.Producer
+	csm consumer.Consumer
+}
+
+// UpdateCustomFlowState update custom flow state
+func (p service) UpdateCustomFlowState(cts *rest.Contexts) (interface{}, error) {
+	opt := new(producer.UpdateCustomFlowStateOption)
+	if err := cts.DecodeInto(opt); err != nil {
+		return nil, err
+	}
+
+	if err := opt.Validate(); err != nil {
+		return nil, errf.NewFromErr(errf.InvalidParameter, err)
+	}
+
+	rty := retry.NewRetryPolicy(consumer.DefRetryCount, consumer.DefRetryRangeMS)
+	err := rty.BaseExec(cts.Kit, func() error {
+		return p.pro.BatchUpdateCustomFlowState(cts.Kit, opt)
+	})
+	if err != nil {
+		logs.Errorf("taskserver batch update flow state failed, err: %v, opt: %+v, rid: %s", err, opt, cts.Kit.Rid)
+		return nil, err
+	}
+
+	return nil, nil
+}
+
+// RetryFlowTask retry flow task, requirements: given flow and task must be `failed` state
+func (p service) RetryFlowTask(cts *rest.Contexts) (any, error) {
+	flowId := cts.PathParameter("flow_id").String()
+	if len(flowId) == 0 {
+		return nil, errf.New(errf.InvalidParameter, "flow_id is required")
+	}
+	taskId := cts.PathParameter("task_id").String()
+	if len(taskId) == 0 {
+		return nil, errf.New(errf.InvalidParameter, "task_id is required")
+	}
+
+	if err := p.pro.RetryFlowTask(cts.Kit, flowId, taskId); err != nil {
+		logs.Errorf("task server retry task(%s) failed, err: %v, opt: %+v, rid: %s", taskId, err, cts.Kit.Rid)
+		return nil, err
+	}
+
+	return nil, nil
+}
+
+// CancelFlow 取消任务，无条件终止
+func (p service) CancelFlow(cts *rest.Contexts) (any, error) {
+	// 终止任务
+	flowId := cts.PathParameter("flow_id").String()
+	if len(flowId) == 0 {
+		return nil, errf.New(errf.InvalidParameter, "flow_id is required")
+	}
+	if err := p.csm.CancelFlow(cts.Kit, flowId); err != nil {
+		logs.Errorf("task server terminate flow(%s) failed, err: %v, opt: %+v, rid: %s", flowId, err, cts.Kit.Rid)
+		return nil, err
+	}
+
+	return nil, nil
+}
+
+// CloneFlow 按原参数重新发起一次任务
+func (p service) CloneFlow(cts *rest.Contexts) (any, error) {
+	flowId := cts.PathParameter("flow_id").String()
+	if len(flowId) == 0 {
+		return nil, errf.New(errf.InvalidParameter, "flow_id is required")
+	}
+	// TODO
+
+	return nil, nil
+}

--- a/cmd/task-server/service/service.go
+++ b/cmd/task-server/service/service.go
@@ -30,6 +30,7 @@ import (
 
 	logicsaction "hcm/cmd/task-server/logics/action"
 	"hcm/cmd/task-server/service/capability"
+	"hcm/cmd/task-server/service/controller"
 	"hcm/cmd/task-server/service/producer"
 	"hcm/cmd/task-server/service/viewer"
 	"hcm/pkg/async"
@@ -227,6 +228,7 @@ func (s *Service) apiSet() *restful.Container {
 
 	producer.Init(c)
 	viewer.Init(c)
+	controller.Init(c)
 
 	return restful.NewContainer().Add(c.WebService)
 }

--- a/pkg/async/backend/backend.go
+++ b/pkg/async/backend/backend.go
@@ -53,6 +53,9 @@ type Backend interface {
 	UpdateTaskStateByCAS(kt *kit.Kit, info *UpdateTaskInfo) error
 	// ListTask 查询任务
 	ListTask(kt *kit.Kit, input *ListInput) ([]model.Task, error)
+
+	// RetryTask 重试任务 将flow置为running, task 置为pending
+	RetryTask(kt *kit.Kit, flowID, taskID string) error
 }
 
 // ListInput 查询输入参数

--- a/pkg/async/backend/mysql.go
+++ b/pkg/async/backend/mysql.go
@@ -20,22 +20,26 @@
 package backend
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 
-	"github.com/jmoiron/sqlx"
-
+	"hcm/pkg/api/core"
 	"hcm/pkg/async/action"
 	"hcm/pkg/async/backend/model"
 	"hcm/pkg/criteria/enumor"
 	"hcm/pkg/dal/dao"
 	"hcm/pkg/dal/dao/orm"
+	"hcm/pkg/dal/dao/tools"
 	"hcm/pkg/dal/dao/types"
 	"hcm/pkg/dal/dao/types/async"
 	tableasync "hcm/pkg/dal/table/async"
 	tabletypes "hcm/pkg/dal/table/types"
 	"hcm/pkg/kit"
+	"hcm/pkg/logs"
 	"hcm/pkg/tools/converter"
+
+	"github.com/jmoiron/sqlx"
 )
 
 // NewMysql create mysql instance
@@ -82,6 +86,87 @@ func (db *mysql) BatchUpdateFlowStateByCAS(kt *kit.Kit, infos []UpdateFlowInfo) 
 	return nil
 }
 
+// RetryTask 重试任务
+func (db *mysql) RetryTask(kt *kit.Kit, flowID, taskID string) error {
+
+	if err := db.checkFlowTaskForRetry(kt, flowID, taskID); err != nil {
+		return err
+	}
+
+	flowUpdate := &typesasync.UpdateFlowInfo{
+		ID:     flowID,
+		Source: enumor.FlowFailed,
+		Target: enumor.FlowPending,
+		Reason: &tableasync.Reason{Message: "retry task " + taskID},
+	}
+	taskUpdate := &typesasync.UpdateTaskInfo{
+		ID:     taskID,
+		Source: enumor.TaskFailed,
+		Target: enumor.TaskPending,
+		Reason: &tableasync.Reason{Message: "retry task " + taskID},
+	}
+
+	_, err := db.dao.Txn().AutoTxn(kt, func(txn *sqlx.Tx, opt *orm.TxnOption) (any, error) {
+
+		if err := db.dao.AsyncFlowTask().UpdateStateByCAS(kt, txn, taskUpdate); err != nil {
+			logs.Errorf("fail to update task status for retry, err: %v, task id: %s, rid: %s",
+				err, taskID, kt.Rid)
+			return nil, err
+		}
+		if err := db.dao.AsyncFlow().UpdateStateByCAS(kt, txn, flowUpdate); err != nil {
+			logs.Errorf("fail to update flow status for retry, err: %v, flow id: %s, rid: %s",
+				err, flowID, kt.Rid)
+			return nil, err
+		}
+		return nil, nil
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (db *mysql) checkFlowTaskForRetry(kt *kit.Kit, flowID string, taskID string) error {
+	if len(flowID) == 0 || len(taskID) == 0 {
+		return errors.New("empty flow id or task id")
+	}
+
+	listOpt := &types.ListOption{
+		Filter: tools.EqualExpression("id", flowID),
+		Page:   core.NewDefaultBasePage(),
+	}
+	flowResp, err := db.dao.AsyncFlow().List(kt, listOpt)
+	if err != nil {
+		return err
+	}
+	if len(flowResp.Details) == 0 {
+		return fmt.Errorf("flow %s not found", flowID)
+	}
+	if flowResp.Details[0].State != enumor.FlowFailed {
+		return fmt.Errorf("flow(%s) state(%s) wrong, only `failed` allowed for retry",
+			flowID, flowResp.Details[0].State)
+	}
+
+	listOpt = &types.ListOption{
+		Filter: tools.ExpressionAnd(
+			tools.RuleEqual("id", taskID),
+			tools.RuleEqual("flow_id", flowID)),
+		Page: core.NewDefaultBasePage(),
+	}
+	taskResp, err := db.dao.AsyncFlowTask().List(kt, listOpt)
+	if err != nil {
+		return err
+	}
+	if len(taskResp.Details) == 0 {
+		return fmt.Errorf("task(%s) of flow(%s) not found", taskID, flowID)
+	}
+	if taskResp.Details[0].State != enumor.TaskFailed {
+		return fmt.Errorf("task(%s) state(%s) wrong, only `failed` allowed for retry",
+			taskID, taskResp.Details[0].State)
+	}
+	return nil
+}
+
 // UpdateTaskStateByCAS CAS更新任务状态
 func (db *mysql) UpdateTaskStateByCAS(kt *kit.Kit, info *UpdateTaskInfo) error {
 	update := &typesasync.UpdateTaskInfo{
@@ -90,7 +175,14 @@ func (db *mysql) UpdateTaskStateByCAS(kt *kit.Kit, info *UpdateTaskInfo) error {
 		Target: info.Target,
 		Reason: info.Reason,
 	}
-	return db.dao.AsyncFlowTask().UpdateStateByCAS(kt, update)
+	_, err := db.dao.Txn().AutoTxn(kt, func(txn *sqlx.Tx, opt *orm.TxnOption) (interface{}, error) {
+		err := db.dao.AsyncFlowTask().UpdateStateByCAS(kt, txn, update)
+		if err != nil {
+			logs.Errorf("fail to update task state cas, err: %v, info: %+v, rid: %s", err, info, kt.Rid)
+		}
+		return nil, err
+	})
+	return err
 }
 
 var _ Backend = new(mysql)

--- a/pkg/async/consumer/consumer.go
+++ b/pkg/async/consumer/consumer.go
@@ -189,6 +189,9 @@ func (csm *consumer) CancelFlow(kt *kit.Kit, flowId string) error {
 	if flow.State == enumor.FlowSuccess {
 		return errors.New("flow has already succeeded")
 	}
+	if flow.State == enumor.FlowFailed {
+		return errors.New("flow has already failed")
+	}
 
 	// 取消flow 需要执行该flow的worker执行，调用该方法的时候，对应flow 不一定在当前worker上，因此这里先
 	// 更改flow状态为canceled，后续步骤由对应worker上的`canceledFlowWatcher`函数继续执行

--- a/pkg/async/consumer/consumer.go
+++ b/pkg/async/consumer/consumer.go
@@ -22,12 +22,18 @@ package consumer
 
 import (
 	"errors"
+	"fmt"
 
+	"hcm/pkg/api/core"
+	"hcm/pkg/criteria/enumor"
+	cvt "hcm/pkg/tools/converter"
 	// 注册Action和Template
 	_ "hcm/pkg/async/action"
 	"hcm/pkg/async/backend"
 	"hcm/pkg/async/compctrl"
 	"hcm/pkg/async/consumer/leader"
+	"hcm/pkg/dal/dao/tools"
+	"hcm/pkg/kit"
 	"hcm/pkg/logs"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -37,23 +43,25 @@ import (
 Consumer 异步任务消费者。组件分为两类，公共组件、主节点组件。
 
 主节点组件：（会根据主从判断，自动启动或者关闭这部分组件）
-	- dispatcher（派发器）: 负责将Pending状态的任务流，派发到指定节点去执行，并将Flow状态改为Scheduled。
-	- watchDog（看门狗）:
-		1. 处理超时任务
-		2. 处理处于Scheduled状态，但执行节点已经挂掉的任务流
-		3. 处理处于Running状态，但执行节点正在Shutdown或者已经挂掉的任务流
+  - dispatcher（派发器）: 负责将Pending状态的任务流，派发到指定节点去执行，并将Flow状态改为Scheduled。
+  - watchDog（看门狗）:
+    1. 处理超时任务
+    2. 处理处于Scheduled状态，但执行节点已经挂掉的任务流
+    3. 处理处于Running状态，但执行节点正在Shutdown或者已经挂掉的任务流
+
 公共组件：
-	- scheduler（调度器）:
-		1. 获取分配给当前节点的处于Scheduled状态的任务流，构建任务流树，将待执行任务推送到执行器执行。
-		2. 分析执行器执行完的任务，判断任务流树状态，如果任务流处理完，更新状态，否则将子节点推送到执行器执行。
-	- executor（执行器）: 准备任务执行所需要的超时控制，共享数据等工具，并执行任务。
-	- commander（指挥者）:
-		1. 强制关闭处于执行中的任务
+  - scheduler（调度器）:
+    1. 获取分配给当前节点的处于Scheduled状态的任务流，构建任务流树，将待执行任务推送到执行器执行。
+    2. 分析执行器执行完的任务，判断任务流树状态，如果任务流处理完，更新状态，否则将子节点推送到执行器执行。
+  - executor（执行器）: 准备任务执行所需要的超时控制，共享数据等工具，并执行任务。
+  - commander（指挥者）:
+    1. 强制关闭处于执行中的任务
 */
 type Consumer interface {
 	compctrl.Closer
 	// Start 启动消费者，开始消费异步任务。
 	Start() error
+	CancelFlow(kit *kit.Kit, flowId string) error
 }
 
 var _ Consumer = new(consumer)
@@ -99,15 +107,17 @@ type consumer struct {
 
 // Start 开启消费者消费功能，注：只有主节点进行异步任务消费。
 func (csm *consumer) Start() error {
-
-	csm.initCommonComponent(csm.opt)
-	csm.initLeaderComponent(csm.opt)
+	// kit of consumer, with node uuid as rid
+	kt := kit.New()
+	kt.Rid = csm.leader.CurrNode()
+	csm.initCommonComponent(kt, csm.opt)
+	csm.initLeaderComponent(kt, csm.opt)
 
 	return nil
 }
 
 // initLeaderComponent 初始化主节点私有组件并启动，同时设置关闭函数
-func (csm *consumer) initLeaderComponent(opt *Option) {
+func (csm *consumer) initLeaderComponent(kt *kit.Kit, opt *Option) {
 
 	handler := NewLeaderChangeHandler(csm.backend, csm.leader, opt)
 	handler.Start()
@@ -116,9 +126,9 @@ func (csm *consumer) initLeaderComponent(opt *Option) {
 }
 
 // initCommonComponent 初始化主从节点公共组件并启动，同时设置关闭函数
-func (csm *consumer) initCommonComponent(opt *Option) {
+func (csm *consumer) initCommonComponent(kt *kit.Kit, opt *Option) {
 	// 设置执行器
-	csm.executor = NewExecutor(csm.backend, opt.Executor)
+	csm.executor = NewExecutor(kt, csm.backend, opt.Executor)
 
 	// 设置调度器
 	csm.scheduler = NewScheduler(csm.backend, csm.executor, csm.leader, opt.Scheduler)
@@ -151,4 +161,43 @@ func (csm *consumer) Close() {
 
 	logs.Infof("consumer close success")
 
+}
+
+// CancelFlow 更新任务状态为 cancel
+func (csm *consumer) CancelFlow(kt *kit.Kit, flowId string) error {
+
+	flowList, err := csm.backend.ListFlow(kt, &backend.ListInput{
+		Filter: tools.EqualExpression("id", flowId),
+		Page:   core.NewDefaultBasePage(),
+	})
+	if err != nil {
+		return err
+	}
+	if len(flowList) == 0 {
+		return errors.New("flow not found " + flowId)
+	}
+	flow := flowList[0]
+	if cvt.PtrToVal(flow.Worker) != csm.leader.CurrNode() {
+		logs.Errorf("unable to cancel flow(%v) which do not belongs to current node, flow node: %s, current node: %s",
+			flowId, cvt.PtrToVal(flow.Worker), csm.leader.CurrNode())
+		return fmt.Errorf("unable to cancel flow(%v) which do not belongs to current node", flowId)
+	}
+
+	if flow.State == enumor.FlowCancel {
+		return errors.New("flow has already been canceled")
+	}
+	if flow.State == enumor.FlowSuccess {
+		return errors.New("flow has already succeeded")
+	}
+
+	// 取消flow 需要执行该flow的worker执行，调用该方法的时候，对应flow 不一定在当前worker上，因此这里先
+	// 更改flow状态为canceled，后续步骤由对应worker上的`canceledFlowWatcher`函数继续执行
+	err = updateFlowStateAndReason(kt, csm.backend, flowId, flow.State,
+		enumor.FlowCancel, "canceled from "+cvt.PtrToVal(flow.Worker))
+	if err != nil {
+		logs.Errorf("fail to update flow state to canceled, err: %v, flow_id: %s, rid: %s", err, flowId, kt.Rid)
+		return err
+	}
+
+	return nil
 }

--- a/pkg/async/consumer/dispatcher.go
+++ b/pkg/async/consumer/dispatcher.go
@@ -32,6 +32,7 @@ import (
 	"hcm/pkg/dal/dao/tools"
 	"hcm/pkg/kit"
 	"hcm/pkg/logs"
+	cvt "hcm/pkg/tools/converter"
 )
 
 // NewDispatcher new dispatcher.
@@ -114,7 +115,7 @@ func (d *Dispatcher) Do(kt *kit.Kit) error {
 			ID:     one.ID,
 			Source: enumor.FlowPending,
 			Target: enumor.FlowScheduled,
-			Worker: nodes[index%len(nodes)], // 任务分发算法，后续看是否优化
+			Worker: cvt.ValToPtr(nodes[index%len(nodes)]), // 任务分发算法，后续看是否优化
 		})
 	}
 

--- a/pkg/async/consumer/executor.go
+++ b/pkg/async/consumer/executor.go
@@ -21,16 +21,24 @@ package consumer
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"sync"
 
+	"hcm/pkg/api/core"
+	"hcm/pkg/async/action"
 	"hcm/pkg/async/action/run"
 	"hcm/pkg/async/backend"
 	"hcm/pkg/async/backend/model"
 	"hcm/pkg/async/compctrl"
 	"hcm/pkg/criteria/constant"
+	"hcm/pkg/criteria/enumor"
+	"hcm/pkg/criteria/errf"
+	"hcm/pkg/dal/dao/tools"
 	tableasync "hcm/pkg/dal/table/async"
 	"hcm/pkg/kit"
 	"hcm/pkg/logs"
+	"hcm/pkg/tools/retry"
 )
 
 // Executor （执行器）: 准备任务执行所需要的超时控制，共享数据等工具，并执行任务。
@@ -46,12 +54,15 @@ type Executor interface {
 	Push(flow *Flow, task *Task)
 	// CancelTasks 关闭指定task_id的任务。
 	CancelTasks(taskIDs []string) error
+	CancelFlow(kt *kit.Kit, flowID string) error
 }
 
 var _ Executor = new(executor)
 
 // executor 定义任务执行器
 type executor struct {
+	kt *kit.Kit
+
 	workerNumber       uint
 	taskExecTimeoutSec uint
 
@@ -73,8 +84,9 @@ func (exec *executor) SetGetSchedulerFunc(f func() Scheduler) {
 }
 
 // NewExecutor 实例化任务执行器
-func NewExecutor(bd backend.Backend, opt *ExecutorOption) Executor {
+func NewExecutor(kt *kit.Kit, bd backend.Backend, opt *ExecutorOption) Executor {
 	return &executor{
+		kt:                 kt,
 		backend:            bd,
 		workerWg:           sync.WaitGroup{},
 		initWg:             sync.WaitGroup{},
@@ -128,8 +140,8 @@ func (exec *executor) initWorkerTask(flow *Flow, task *Task) {
 	}
 
 	// 设置task执行所需要的 kit，更新Task函数，所属流
-	task.InitDep(run.NewExecuteContext(task.Kit, flow.ShareData), func(kt *kit.Kit, task *model.Task) error {
-		return exec.backend.UpdateTask(kt, task)
+	task.InitDep(run.NewExecuteContext(task.Kit, flow.ShareData), func(taskKit *kit.Kit, task *model.Task) error {
+		return exec.backend.UpdateTask(exec.kt, task)
 	}, flow)
 
 	// cancel存储到cancelMap中
@@ -156,18 +168,122 @@ func (exec *executor) workerDo(task *Task) (err error) {
 
 	// cancelMap清理执行成功/失败的任务
 	defer exec.cancelMap.Delete(task.ID)
+	// 无论任务成功还是失败，都需要交给scheduler分析任务流的状态
+	// 执行完的任务回写到scheduler用于获取待执行的任务
+	defer exec.GetSchedulerFunc().EntryTask(task)
+	var runErr error
+	var failedRet any
 
 	// 执行任务
-	if err = task.Run(); err != nil {
-		logs.Errorf("task run failed, err: %v, task: %+v, rid: %s", err, task, task.Kit.Rid)
-
-		// 无论任务成功还是失败，都需要交给调度器分析任务流的状态
+	act, exist := action.GetAction(task.ActionName)
+	if !exist {
+		return fmt.Errorf("action: %s not found", task.ActionName)
 	}
 
-	// 执行完的任务回写到调度器用于获取待执行的任务
-	exec.GetSchedulerFunc().EntryTask(task)
+	if err := task.ValidateBeforeExec(act); err != nil {
+		return err
+	}
 
-	return err
+	defer func() {
+		if runErr == nil {
+			return
+		}
+		err = runErr
+		logs.Errorf("task run failed, err: %v, task: %+v, result: %+v, rid: %s",
+			runErr, task, failedRet, exec.kt.Rid)
+		if errf.IsContextCanceled(runErr) {
+			task.State = enumor.TaskCancel
+			return
+		}
+		nextState := enumor.TaskFailed
+		if patchErr := exec.UpdateTask(task, nextState, runErr.Error(), failedRet); patchErr != nil {
+			logs.Errorf("task set %s state failed after run failed, err: %v, patchErr: %v, exeRid: %s, "+
+				"taskRid: %s", nextState, runErr, patchErr, exec.kt.Rid, task.Kit.Rid)
+			err = fmt.Errorf("task set %s state failed, after run failed, err: %v, patchErr: %v",
+				nextState, runErr, patchErr)
+			return
+		}
+		return
+	}()
+
+	if !task.Retry.IsEnable() {
+		_, failedRet, runErr = exec.runTaskOnce(task, act)
+		return
+	}
+
+	if task.State == enumor.TaskRollback && task.Reason.RollbackCount >= task.Retry.Policy.Count {
+		// 超过指定重试次数，置为失败
+		runErr = errors.New("too many retries")
+		return
+	}
+	// 减去已经执行的count
+	task.Retry.Policy.Count -= task.Reason.RollbackCount
+	failedRet, runErr = task.Retry.Run(func() (stop bool, failRet any, err error) {
+		needRetry, failRet, err := exec.runTaskOnce(task, act)
+		if err == nil {
+			return false, nil, nil
+		}
+
+		if !needRetry {
+			return true, failRet, err
+		}
+		// 允许重试，将Task状态由 running -> rollback，进行回滚
+		if patchErr := exec.UpdateTask(task, enumor.TaskRollback, err.Error(), failRet); patchErr != nil {
+			e := fmt.Errorf("task set rollback state failed, after runAction failed, err: %v, patchErr: %v",
+				err, patchErr)
+			return false, failRet, e
+		}
+
+		return false, nil, nil
+	})
+
+	return nil
+}
+
+// runTaskOnce 只有执行Action运行逻辑失败才会允许重试，更改状态失败不进行重试。
+// 如果执行成功直接写入状态和结果，失败时才将状态和结果返回到上层
+func (exec *executor) runTaskOnce(task *Task, act action.Action) (needRetry bool, failedResult any, err error) {
+	params, err := task.prepareParams(act)
+	if err != nil {
+		return false, nil, err
+	}
+	if task.State == enumor.TaskRollback {
+		rollbackAct, ok := act.(action.RollbackAction)
+		if !ok {
+			return false, nil, fmt.Errorf("action: %s not has RollbackAction", act.Name())
+		}
+
+		if err = rollbackAct.Rollback(task.ExecuteKit, params); err != nil {
+			return true, nil, fmt.Errorf("rollback failed, err: %v", err)
+		}
+
+		if err = exec.UpdateTaskState(task, enumor.TaskPending); err != nil {
+			return false, nil, err
+		}
+	}
+
+	if task.State == enumor.TaskPending {
+		if err = exec.UpdateTaskState(task, enumor.TaskRunning); err != nil {
+			return false, nil, err
+		}
+
+		result, err := act.Run(task.ExecuteKit, params)
+		if err != nil {
+			if errf.IsContextCanceled(err) {
+				// 被取消不需要重试
+				return false, result, err
+			}
+			return true, result, fmt.Errorf("run failed, err: %v", err)
+		}
+
+		// 如果执行成功，返回 result 属于成功结果，设置成功状态时，同时设置成功结果。如果执行失败，
+		// 结果属于失败结果，交与上层更新失败或回滚等操作，更新失败结果。
+		if err = exec.UpdateTaskStateResult(task, enumor.TaskSuccess, result); err != nil {
+			return false, result, err
+		}
+	}
+
+	return false, nil, nil
 }
 
 // Push 任务写入到initQueue
@@ -206,6 +322,42 @@ func (exec *executor) CancelTasks(taskIDs []string) error {
 	return nil
 }
 
+// CancelFlow 取消指定id flow
+func (exec *executor) CancelFlow(kt *kit.Kit, flowId string) error {
+
+	taskList, err := exec.backend.ListTask(kt, &backend.ListInput{
+		Filter: tools.EqualExpression("flow_id", flowId),
+		Page:   core.NewDefaultBasePage(),
+	})
+	if err != nil {
+		return err
+	}
+	cancelIDs := make([]string, 0)
+	for _, task := range taskList {
+		switch task.State {
+
+		case enumor.TaskPending, enumor.TaskInit, enumor.TaskRollback, enumor.TaskFailed, enumor.TaskRunning:
+			// 	更新数据库状态
+			err := exec.UpdateTask(&Task{Task: task}, enumor.TaskCancel, string(task.State), nil)
+			logs.Errorf("fail to update task(%s) state for cancel, err: %v, rid: %s", task.ID, err, kt.Rid)
+			cancelIDs = append(cancelIDs, task.ID)
+		case enumor.TaskSuccess, enumor.TaskCancel:
+			// 	跳过
+		}
+	}
+	if len(cancelIDs) == 0 {
+		return nil
+	}
+	// cancel 后在executor 中写回task canceled状态
+	if err := exec.CancelTasks(cancelIDs); err != nil {
+		logs.Errorf("fail to cancel task, err: %v, flow id: %s, task ids %v, rid: %s",
+			err, flowId, cancelIDs, kt.Rid)
+		return err
+	}
+
+	return nil
+}
+
 // Close 执行器关闭函数
 func (exec *executor) Close() {
 
@@ -221,4 +373,36 @@ func (exec *executor) Close() {
 
 	logs.Infof("executor close success")
 
+}
+
+// UpdateTaskState update task state.
+func (exec *executor) UpdateTaskState(task *Task, state enumor.TaskState) error {
+	return exec.UpdateTask(task, state, "", nil)
+}
+
+// UpdateTaskStateResult update task state and result.
+func (exec *executor) UpdateTaskStateResult(task *Task, state enumor.TaskState, result interface{}) error {
+	return exec.UpdateTask(task, state, "", result)
+}
+
+// UpdateTask update task, record state of cancel state
+func (exec *executor) UpdateTask(task *Task, state enumor.TaskState, reason string, result interface{}) error {
+	md, err := task.buildTaskUpdateModel(exec.kt, state, reason, result)
+	if err != nil {
+		return err
+	}
+
+	rty := retry.NewRetryPolicy(DefRetryCount, DefRetryRangeMS)
+	err = rty.BaseExec(exec.kt, func() error {
+		return exec.backend.UpdateTask(exec.kt, md)
+	})
+	if err != nil {
+		logs.Errorf("task update state failed, err: %v, retryCount: %d, id: %s, state: %s, reason: %s, rid: %s",
+			err, DefRetryCount, task.ID, state, reason, exec.kt.Rid)
+		return err
+	}
+
+	task.State = state
+
+	return nil
 }

--- a/pkg/async/consumer/scheduler.go
+++ b/pkg/async/consumer/scheduler.go
@@ -26,6 +26,7 @@ import (
 
 	"hcm/pkg/api/core"
 	"hcm/pkg/async/backend"
+	"hcm/pkg/async/backend/model"
 	"hcm/pkg/async/compctrl"
 	"hcm/pkg/async/consumer/leader"
 	"hcm/pkg/criteria/constant"
@@ -34,7 +35,7 @@ import (
 	tableasync "hcm/pkg/dal/table/async"
 	"hcm/pkg/kit"
 	"hcm/pkg/logs"
-	"hcm/pkg/runtime/filter"
+	cvt "hcm/pkg/tools/converter"
 	"hcm/pkg/tools/retry"
 	"hcm/pkg/tools/slice"
 )
@@ -52,6 +53,8 @@ type Scheduler interface {
 
 	// EntryTask 分析执行完的任务，并解析出当前任务的子任务去执行。
 	EntryTask(task *Task)
+	// DeleteFlowTaskTree 清空任务树，阻止继续调度
+	DeleteFlowTaskTree(flowID string)
 }
 
 // scheduler 定义任务流调度器
@@ -91,8 +94,9 @@ func (sch *scheduler) Start() {
 	logs.Infof("scheduler start, worker number: %d, interval: %v", sch.workerNumber, sch.watchIntervalSec)
 
 	// 定期获取等待执行的任务流
-	sch.workerWg.Add(1)
-	go sch.startWatcher(sch.watchScheduledFlow)
+	sch.workerWg.Add(2)
+	go sch.scheduledFlowWatcher()
+	go sch.canceledFlowWatcher()
 
 	// 启动workerNumber个协程进行任务流解析
 	for i := 0; i < int(sch.workerNumber); i++ {
@@ -101,18 +105,19 @@ func (sch *scheduler) Start() {
 	}
 }
 
-// startWatcher 定期执行do函数体
-func (sch *scheduler) startWatcher(do func(kt *kit.Kit) error) {
+// flowWatcher 定期查询调度到该节点的flow
+func (sch *scheduler) scheduledFlowWatcher() {
 	for {
 		select {
 		case <-sch.closeCh:
 			break
 		default:
 		}
-
+		// Kit: Kit initiate, 每次执行创建新kit
 		kt := NewKit()
-		if err := do(kt); err != nil {
-			logs.Errorf("%s: scheduler watcher do failed, err: %v, rid: %s", constant.AsyncTaskWarnSign, err, kt.Rid)
+		if err := sch.runScheduledFlow(kt); err != nil {
+			logs.Errorf("%s: scheduler watch scheduled flow  failed, err: %v, rid: %s",
+				constant.AsyncTaskWarnSign, err, kt.Rid)
 		}
 
 		time.Sleep(sch.watchIntervalSec)
@@ -122,28 +127,16 @@ func (sch *scheduler) startWatcher(do func(kt *kit.Kit) error) {
 }
 
 // queryCurrNodeFlow 查询主节点分配给当前节点处于 Scheduled 状态的任务流。
-func (sch *scheduler) queryCurrNodeFlow(kt *kit.Kit, limit int32) ([]*Flow, error) {
+func (sch *scheduler) queryCurrNodeFlow(kt *kit.Kit, state enumor.FlowState, limit int32) (
+	[]model.Flow, error) {
 
 	if limit > int32(core.DefaultMaxPageLimit) {
 		return nil, fmt.Errorf("limit should <= %d", core.DefaultMaxPageLimit)
 	}
-
 	input := &backend.ListInput{
-		Filter: &filter.Expression{
-			Op: filter.And,
-			Rules: []filter.RuleFactory{
-				&filter.AtomRule{
-					Field: "state",
-					Op:    filter.Equal.Factory(),
-					Value: enumor.FlowScheduled,
-				},
-				&filter.AtomRule{
-					Field: "worker",
-					Op:    filter.Equal.Factory(),
-					Value: sch.leader.CurrNode(),
-				},
-			},
-		},
+		Filter: tools.ExpressionAnd(
+			tools.RuleEqual("state", state),
+			tools.RuleEqual("worker", sch.leader.CurrNode())),
 		Page: &core.BasePage{
 			Start: 0,
 			Limit: uint(limit),
@@ -154,16 +147,58 @@ func (sch *scheduler) queryCurrNodeFlow(kt *kit.Kit, limit int32) ([]*Flow, erro
 		logs.Errorf("list flows failed, err: %v, rid: %s", err, kt.Rid)
 		return nil, err
 	}
+	return result, nil
+}
 
-	flows := make([]*Flow, 0)
-	for _, one := range result {
-		flows = append(flows, &Flow{
-			Flow: one,
-			Kit:  kt.NewSubKit(),
-		})
+// canceledFlowWatcher 查询当前节点上被取消的flow并执行task取消操作
+func (sch *scheduler) canceledFlowWatcher() {
+	for {
+		select {
+		case <-sch.closeCh:
+			break
+		default:
+		}
+		// Kit: Kit initiate, 每次执行创建新kit
+		kt := NewKit()
+		if err := sch.handleCanceledFlow(kt); err != nil {
+			logs.Errorf("%s: scheduler watch canceled failed, err: %v, rid: %s",
+				constant.AsyncTaskWarnSign, err, kt.Rid)
+		}
+
+		time.Sleep(sch.watchIntervalSec)
 	}
 
-	return flows, nil
+	sch.workerWg.Done()
+}
+
+func (sch *scheduler) handleCanceledFlow(kt *kit.Kit) error {
+
+	dbFlows, err := sch.queryCurrNodeFlow(kt, enumor.FlowCancel, listScheduledFlowLimit)
+	if err != nil {
+		logs.Errorf("fail to list canceled flow, err: %v, rid: %s", err, kt.Rid)
+		return err
+	}
+	if len(dbFlows) == 0 {
+		return nil
+	}
+	for _, flow := range dbFlows {
+		logs.Infof("canceling flow: %s", flow.ID)
+		// 清空任务树，阻止继续调度
+		sch.DeleteFlowTaskTree(flow.ID)
+		err = updateFlowToCancel(kt, sch.backend, flow.ID, cvt.PtrToVal(flow.Worker), enumor.FlowCancel)
+		if err != nil {
+			logs.Errorf("fail to update flow clear worker id, err: %v, flow id: %s rid: %s",
+				err, flow.ID, kt.Rid)
+			// keep canceling other flow
+			continue
+		}
+
+		if err := sch.executor.CancelFlow(kt, flow.ID); err != nil {
+			logs.Errorf("fail to handle flow canceling, err: %v, flow id: %s, rid: %s", err, flow.ID, kt.Rid)
+			// keep canceling other flow
+		}
+	}
+	return nil
 }
 
 // listTaskByFlowID 查询当前FlowID全部的任务节点
@@ -188,7 +223,8 @@ func listTaskByFlowID(kt *kit.Kit, bd backend.Backend, flowID string) ([]*Task, 
 		for _, one := range result {
 			tasks = append(tasks, &Task{
 				Task: one,
-				Kit:  kt.NewSubKit(),
+				// Note: second sub kit, flow -> task
+				Kit: kt.NewSubKit(),
 			})
 		}
 
@@ -338,15 +374,45 @@ func updateFlowStateAndReason(kt *kit.Kit, bd backend.Backend, flowID string, so
 	return nil
 }
 
-// watchScheduledFlow 查询主节点分配给当前节点的
-func (sch *scheduler) watchScheduledFlow(kt *kit.Kit) error {
+// updateFlowToCancel 状态改为取消，清空 worker字段,
+func updateFlowToCancel(kt *kit.Kit, bd backend.Backend, flowId, oldWorkerID string, source enumor.FlowState) error {
+
+	info := backend.UpdateFlowInfo{
+		ID:     flowId,
+		Source: source,
+		Target: enumor.FlowCancel,
+		Reason: &tableasync.Reason{
+			Message: "canceled from " + oldWorkerID,
+		},
+		Worker: cvt.ValToPtr(""),
+	}
+
+	rty := retry.NewRetryPolicy(DefRetryCount, DefRetryRangeMS)
+	err := rty.BaseExec(kt, func() error {
+		return bd.BatchUpdateFlowStateByCAS(kt, []backend.UpdateFlowInfo{info})
+	})
+	if err != nil {
+		logs.Errorf("fail to update flow state to cancel, err: %v, flow id: %s, rid: %s", err, flowId, kt.Rid)
+		return err
+	}
+
+	return nil
+}
+
+// watchScheduledFlow 查询主节点分配给当前节点的的flow，并执行
+func (sch *scheduler) runScheduledFlow(kt *kit.Kit) error {
 
 	// 从DB中获取一条待执行的任务流并更新状态为执行中
-	flows, err := sch.queryCurrNodeFlow(kt, listScheduledFlowLimit)
+	dbFlows, err := sch.queryCurrNodeFlow(kt, enumor.FlowScheduled, listScheduledFlowLimit)
 	if err != nil {
 		logs.Errorf("")
 		return err
 	}
+
+	flows := slice.Map(dbFlows, func(one model.Flow) *Flow {
+		// Note: first sub kit, scheduler.watcher -> flow
+		return &Flow{Flow: one, Kit: kt.NewSubKit()}
+	})
 
 	if len(flows) == 0 {
 		logs.V(3).Infof("current node: %s not found scheduled flow to handleRunningFlow, rid: %s",
@@ -383,6 +449,10 @@ func (sch *scheduler) goWorker() {
 
 // 任务流解析函数体，根据任务获取下次可执行的任务集合
 func (sch *scheduler) executeNext(kt *kit.Kit, task *Task) error {
+	if task.State == enumor.TaskCancel {
+		// skip canceled task
+		return nil
+	}
 	tree, ok := sch.getTaskTree(task.FlowID)
 	if !ok {
 		logs.Errorf("execute next get task tree failed, flowID: %s, rid: %s", task.FlowID, kt.Rid)
@@ -390,34 +460,35 @@ func (sch *scheduler) executeNext(kt *kit.Kit, task *Task) error {
 	}
 
 	// 获取下次执行的任务
-	ids := tree.Root.GetNextTaskNodes(task)
-	if len(ids) == 0 {
+	executableIds := tree.Root.GetNextExecutableTaskNodes(task)
+	if len(executableIds) == 0 {
+		// 没有可执行的节点了，计算整棵树的执行状态，更新flow结果
 		state := tree.Root.ComputeState()
-
-		if state == enumor.FlowSuccess {
+		switch state {
+		case enumor.FlowSuccess:
 			if err := updateFlowState(kt, sch.backend, task.FlowID, enumor.FlowRunning, state); err != nil {
-				logs.Errorf("update flow state to %s failed, err: %v, rid: %s", state, err, kt.Rid)
+				logs.Errorf("update flow state to `%s` failed, err: %v, rid: %s", state, err, kt.Rid)
 				return err
 			}
 
-			sch.taskTrees.Delete(task.FlowID)
-		}
-
-		if state == enumor.FlowFailed {
+			sch.DeleteFlowTaskTree(task.FlowID)
+		case enumor.FlowFailed:
 			if err := updateFlowStateAndReason(kt, sch.backend, task.FlowID, enumor.FlowRunning, state,
 				ErrSomeTaskExecFailed); err != nil {
 
-				logs.Errorf("update flow state to %s failed, err: %v, rid: %s", state, err, kt.Rid)
+				logs.Errorf("update flow state to `%s` failed, err: %v, rid: %s", state, err, kt.Rid)
 				return err
 			}
 
-			sch.taskTrees.Delete(task.FlowID)
+			sch.DeleteFlowTaskTree(task.FlowID)
+		case enumor.FlowCancel:
+			// task cancel 一般是由flow状态触发，因此这里不处理
 		}
 
 		return nil
 	}
 
-	return sch.pushTasks(kt, tree.Flow, ids)
+	return sch.pushTasks(kt, tree.Flow, executableIds)
 }
 
 func (sch *scheduler) pushTasks(kt *kit.Kit, flow *Flow, ids []string) error {
@@ -470,4 +541,10 @@ func (sch *scheduler) Close() {
 
 	logs.Infof("scheduler receive close cmd, start to close")
 
+}
+
+// DeleteFlowTaskTree 清空任务树，阻止继续调度
+func (sch *scheduler) DeleteFlowTaskTree(flowID string) {
+
+	sch.taskTrees.Delete(flowID)
 }

--- a/pkg/async/consumer/task.go
+++ b/pkg/async/consumer/task.go
@@ -42,14 +42,14 @@ type Task struct {
 	Kit *kit.Kit `json:"-"`
 
 	ExecuteKit run.ExecuteKit `json:"-"`
-	Patch      func(kt *kit.Kit, task *model.Task) error
+	Patch      func(taskKit *kit.Kit, task *model.Task) error
 	Flow       *Flow
 }
 
 // ValidateBeforeExec task validate before execute.
 func (task *Task) ValidateBeforeExec(act action.Action) error {
 	switch task.State {
-	case enumor.TaskPending:
+	case enumor.TaskPending, enumor.TaskRollback:
 	default:
 		return fmt.Errorf("task can not run，state: %s", task.State)
 	}
@@ -99,59 +99,6 @@ func (task *Task) InitDep(kt run.ExecuteKit, patch func(kt *kit.Kit, task *model
 	task.Flow = flow
 }
 
-// Run 任务执行。
-func (task *Task) Run() error {
-
-	act, exist := action.GetAction(task.ActionName)
-	if !exist {
-		return fmt.Errorf("action: %s not found", task.ActionName)
-	}
-
-	if err := task.ValidateBeforeExec(act); err != nil {
-		return err
-	}
-
-	var runErr error
-	var failedResult interface{}
-	if !task.Retry.IsEnable() {
-		_, failedResult, runErr = task.runOnce(act)
-	} else {
-		failedResult, runErr = task.Retry.Run(func() (interface{}, error) {
-			needRetry, failed, err := task.runOnce(act)
-			if err == nil {
-				return nil, nil
-			}
-
-			if !needRetry {
-				return failed, err
-			}
-
-			// 允许重试，将Task状态由 running -> rollback，进行回滚
-			if patchErr := task.UpdateTask(enumor.TaskRollback, err.Error(), failed); patchErr != nil {
-				return failed, fmt.Errorf("task set rollback state failed, after runAction failed, err: %v, "+
-					"patchErr: %v", err, patchErr)
-			}
-
-			return nil, nil
-		})
-	}
-	if runErr != nil {
-		logs.Errorf("task run failed, err: %v, task: %+v, result: %+v, rid: %s", runErr, task, failedResult,
-			task.ExecuteKit.Kit().Rid)
-
-		if patchErr := task.UpdateTask(enumor.TaskFailed, runErr.Error(), failedResult); patchErr != nil {
-			logs.Errorf("task set failed state failed, after run failed, err: %v, patchErr: %v, rid: %s",
-				runErr, patchErr, task.ExecuteKit.Kit().Rid)
-			return fmt.Errorf("task set failed state failed, after run failed, err: %v, patchErr: %v",
-				runErr, patchErr)
-		}
-
-		return runErr
-	}
-
-	return nil
-}
-
 // Rollback 任务强制回滚，从Running或者Rollback状态
 func (task *Task) Rollback() error {
 
@@ -187,28 +134,26 @@ func (task *Task) Rollback() error {
 	return task.rollback(p, act)
 }
 
-func (task *Task) runOnce(act action.Action) (needRetry bool, failedResult interface{}, err error) {
+func (task *Task) prepareParams(act action.Action) (params any, err error) {
 	if len(task.Params) == 0 {
-		return task.runAction(nil, act)
+		return nil, nil
 	}
 
 	paramAct, ok := act.(action.ParameterAction)
 	if !ok {
-		return task.runAction(nil, act)
+		return nil, nil
 	}
 
 	p := paramAct.ParameterNew()
 	if p == nil {
-		return task.runAction(nil, act)
+		return nil, nil
 	}
-
 	if err = action.Decode(task.Params, p); err != nil {
 		logs.Errorf("task decode params failed, params: %s, type: %s, rid: %s", task.Params,
 			reflect.TypeOf(p).String(), task.ExecuteKit.Kit().Rid)
-		return false, nil, fmt.Errorf("task decode params failed, err: %v", err)
+		return nil, fmt.Errorf("task decode params failed, err: %v", err)
 	}
-
-	return task.runAction(p, act)
+	return p, nil
 }
 
 // rollback 任务强制回滚，从Running或者Rollback状态
@@ -229,44 +174,6 @@ func (task *Task) rollback(params interface{}, act action.Action) error {
 	return nil
 }
 
-// runAction 执行Action，且只有执行Action运行逻辑失败才会允许重试，更改状态失败不进行重试。
-func (task *Task) runAction(params interface{}, act action.Action) (retry bool, failedResult interface{}, err error) {
-
-	if task.State == enumor.TaskRollback {
-		rollbackAct, ok := act.(action.RollbackAction)
-		if !ok {
-			return false, nil, fmt.Errorf("action: %s not has RollbackAction", act.Name())
-		}
-
-		if err = rollbackAct.Rollback(task.ExecuteKit, params); err != nil {
-			return true, nil, fmt.Errorf("rollback failed, err: %v", err)
-		}
-
-		if err = task.UpdateState(enumor.TaskPending); err != nil {
-			return false, nil, err
-		}
-	}
-
-	if task.State == enumor.TaskPending {
-		if err = task.UpdateState(enumor.TaskRunning); err != nil {
-			return false, nil, err
-		}
-
-		result, err := act.Run(task.ExecuteKit, params)
-		if err != nil {
-			return true, result, fmt.Errorf("run failed, err: %v", err)
-		}
-
-		// 如果执行成功，返回 result 属于成功结果，设置成功状态时，同时设置成功结果。如果执行失败，
-		// 结果属于失败结果，交与上层更新失败或回滚等操作，更新失败结果。
-		if err = task.UpdateStateResult(enumor.TaskSuccess, result); err != nil {
-			return false, result, err
-		}
-	}
-
-	return false, nil, nil
-}
-
 // UpdateState update task state.
 func (task *Task) UpdateState(state enumor.TaskState) error {
 	return task.UpdateTask(state, "", nil)
@@ -279,26 +186,12 @@ func (task *Task) UpdateStateResult(state enumor.TaskState, result interface{}) 
 
 // UpdateTask update task.
 func (task *Task) UpdateTask(state enumor.TaskState, reason string, result interface{}) error {
-	md := &model.Task{
-		ID:    task.ID,
-		State: state,
-		Reason: &tableasync.Reason{
-			Message: reason,
-		},
+	md, err := task.buildTaskUpdateModel(task.ExecuteKit.Kit(), state, reason, result)
+	if err != nil {
+		return err
 	}
-
-	if result != nil {
-		field, err := types.NewJsonField(result)
-		if err != nil {
-			logs.Errorf("update task marshal result failed, err: %v, result: %v, rid: %s", err, result,
-				task.ExecuteKit.Kit().Rid)
-			return err
-		}
-		md.Result = field
-	}
-
 	rty := retry.NewRetryPolicy(DefRetryCount, DefRetryRangeMS)
-	err := rty.BaseExec(task.ExecuteKit.Kit(), func() error {
+	err = rty.BaseExec(task.ExecuteKit.Kit(), func() error {
 		return task.Patch(task.ExecuteKit.Kit(), md)
 	})
 	if err != nil {
@@ -310,4 +203,36 @@ func (task *Task) UpdateTask(state enumor.TaskState, reason string, result inter
 	task.State = state
 
 	return nil
+}
+
+func (task *Task) buildTaskUpdateModel(kt *kit.Kit, state enumor.TaskState, reason string,
+	result interface{}) (*model.Task, error) {
+
+	md := &model.Task{
+		ID:    task.ID,
+		State: state,
+		Reason: &tableasync.Reason{
+			Message:       task.Reason.Message,
+			RollbackCount: task.Reason.RollbackCount,
+			PreState:      task.State,
+		},
+	}
+	if reason != "" {
+		md.Reason.Message = reason
+	}
+
+	// 更新为rollback，记录rollback次数
+	if state == enumor.TaskRollback {
+		md.Reason.RollbackCount = task.Reason.RollbackCount + 1
+	}
+	if result != nil {
+		field, err := types.NewJsonField(result)
+		if err != nil {
+			logs.Errorf("update task marshal result failed, err: %v, result: %v, rid: %s",
+				err, result, kt.Rid)
+			return nil, err
+		}
+		md.Result = field
+	}
+	return md, nil
 }

--- a/pkg/async/consumer/task_tree.go
+++ b/pkg/async/consumer/task_tree.go
@@ -28,6 +28,7 @@ import (
 )
 
 const (
+	// VirtualTaskRootID ...
 	VirtualTaskRootID = "virtual_root"
 )
 
@@ -95,7 +96,7 @@ func (t *TaskNode) CanBeExecuted() bool {
 
 // Executable check can executable: no parent or all parents CanExecuteChild(state == TaskSuccess )
 func (t *TaskNode) Executable() bool {
-	if t.State != enumor.TaskPending {
+	if t.State != enumor.TaskPending && t.State != enumor.TaskRollback {
 		return false
 	}
 
@@ -114,9 +115,12 @@ func (t *TaskNode) Executable() bool {
 
 // ComputeState compute state
 func (t *TaskNode) ComputeState() (state enumor.FlowState) {
-	walkNode(t, func(node *TaskNode) bool {
+	walkNode(t, func(node *TaskNode) (proceed bool) {
 		switch node.State {
 		// 如果Task存在失败节点，无法继续遍历当前节点子节点。
+		case enumor.TaskCancel:
+			state = enumor.FlowCancel
+			return false
 		case enumor.TaskFailed:
 			state = enumor.FlowFailed
 			return false
@@ -124,6 +128,7 @@ func (t *TaskNode) ComputeState() (state enumor.FlowState) {
 		case enumor.TaskSuccess:
 			state = enumor.FlowSuccess
 			return true
+
 		// 如果当前节点处于其他运行中间状态，无法继续遍历当前节点子节点。
 		default:
 			state = enumor.FlowRunning
@@ -158,13 +163,13 @@ func (t *TaskNode) GetExecStateTasks() (ids []string) {
 	return
 }
 
-// GetNextTaskNodes get next task nodes
-func (t *TaskNode) GetNextTaskNodes(completedOrRetryTask *Task) (executable []string) {
-	walkNode(t, func(node *TaskNode) bool {
+// GetNextExecutableTaskNodes get next executable task nodes
+func (t *TaskNode) GetNextExecutableTaskNodes(completedOrRetryTask *Task) (executable []string) {
+	walkNode(t, func(node *TaskNode) (proceed bool) {
 		if node.TaskID == completedOrRetryTask.ID {
 			node.State = completedOrRetryTask.State
-
-			if node.State == enumor.TaskPending {
+			// running 和 rollback 都要放回去执行
+			if node.State == enumor.TaskRunning || node.State == enumor.TaskRollback {
 				executable = append(executable, node.TaskID)
 				return false
 			}
@@ -292,13 +297,13 @@ func buildTaskNodeMap(tasks []*Task) (map[action.ActIDType]*TaskNode, error) {
 	return m, nil
 }
 
-func walkNode(root *TaskNode, walkFunc func(node *TaskNode) bool) {
+func walkNode(root *TaskNode, walkFunc func(node *TaskNode) (proceed bool)) {
 	dfsWalk(root, walkFunc)
 }
 
 // dfsWalk 从某个节点进行深度优先遍历并依次遍历它的子节点
 // Note: walkFunc
-func dfsWalk(root *TaskNode, walkFunc func(node *TaskNode) (isGoing bool)) (stop bool) {
+func dfsWalk(root *TaskNode, walkFunc func(node *TaskNode) (proceed bool)) (stop bool) {
 	if root.TaskID != VirtualTaskRootID {
 		if !walkFunc(root) {
 			return false

--- a/pkg/async/producer/add_custom_flow.go
+++ b/pkg/async/producer/add_custom_flow.go
@@ -152,3 +152,14 @@ func (p *producer) BatchUpdateCustomFlowState(kt *kit.Kit, opt *UpdateCustomFlow
 
 	return nil
 }
+
+// RetryFlowTask retry task of flow
+func (p *producer) RetryFlowTask(kt *kit.Kit, flowID, taskID string) error {
+
+	err := p.backend.RetryTask(kt, flowID, taskID)
+	if err != nil {
+		logs.Errorf("retry task(%s) of flow(%s) failed, err: %v, rid: %s", taskID, flowID, err, kt.Rid)
+		return err
+	}
+	return nil
+}

--- a/pkg/async/producer/producer.go
+++ b/pkg/async/producer/producer.go
@@ -34,6 +34,7 @@ type Producer interface {
 	AddTemplateFlow(kt *kit.Kit, opt *AddTemplateFlowOption) (id string, err error)
 	AddCustomFlow(kt *kit.Kit, opt *AddCustomFlowOption) (id string, err error)
 	BatchUpdateCustomFlowState(kt *kit.Kit, opt *UpdateCustomFlowStateOption) error
+	RetryFlowTask(kt *kit.Kit, flowID, taskID string) error
 }
 
 var _ Producer = new(producer)

--- a/pkg/criteria/enumor/async.go
+++ b/pkg/criteria/enumor/async.go
@@ -34,7 +34,7 @@ const (
 	// TaskRollback task state is rollback.
 	TaskRollback TaskState = "rollback"
 	// TaskCancel task state is cancel.
-	TaskCancel TaskState = "cancel"
+	TaskCancel TaskState = "canceled"
 	// TaskSuccess task state is success
 	TaskSuccess TaskState = "success"
 	// TaskFailed task state is failed
@@ -54,7 +54,7 @@ const (
 	// FlowRunning flow state is running
 	FlowRunning FlowState = "running"
 	// FlowCancel flow state is cancel
-	FlowCancel FlowState = "cancel"
+	FlowCancel FlowState = "canceled"
 	// FlowSuccess flow state is success
 	FlowSuccess FlowState = "success"
 	// FlowFailed flow state is failed

--- a/pkg/dal/dao/async/flow.go
+++ b/pkg/dal/dao/async/flow.go
@@ -170,7 +170,7 @@ func (dao *AsyncFlowDao) UpdateStateByCAS(kt *kit.Kit, tx *sqlx.Tx, info *typesa
 	}
 
 	setSql := "set state = :target"
-	if len(info.Worker) != 0 {
+	if info.Worker != nil {
 		setSql += ", worker = :worker"
 	}
 
@@ -194,7 +194,7 @@ func (dao *AsyncFlowDao) UpdateStateByCAS(kt *kit.Kit, tx *sqlx.Tx, info *typesa
 	}
 
 	if effected == 0 {
-		return errf.Newf(errf.RecordNotUpdate, "flow[%s: %s] update state: %s, worker: %s failed",
+		return errf.Newf(errf.RecordNotUpdate, "flow[%s] update state: `%s`->`%s`, worker: %+v failed",
 			info.ID, info.Source, info.Target, info.Worker)
 	}
 

--- a/pkg/dal/dao/types/async/flow.go
+++ b/pkg/dal/dao/types/async/flow.go
@@ -37,7 +37,7 @@ type UpdateFlowInfo struct {
 	Source enumor.FlowState   `json:"source" validate:"required"`
 	Target enumor.FlowState   `json:"target" validate:"required"`
 	Reason *tableasync.Reason `json:"reason" validate:"omitempty"`
-	Worker string             `json:"worker" validate:"omitempty"`
+	Worker *string            `json:"worker" validate:"omitempty"`
 }
 
 // Validate UpdateFlowInfo.

--- a/pkg/dal/table/async/types.go
+++ b/pkg/dal/table/async/types.go
@@ -22,12 +22,16 @@ package tableasync
 import (
 	"database/sql/driver"
 
+	"hcm/pkg/criteria/enumor"
 	"hcm/pkg/dal/table/types"
 )
 
 // Reason define async flow reason
 type Reason struct {
-	Message string `json:"message"`
+	Message  string           `json:"message,omitempty"`
+	PreState enumor.TaskState `json:"pre_state,omitempty"`
+	// 改为rollback的次数
+	RollbackCount uint `json:"rollback_count,omitempty"`
 }
 
 // Scan is used to decode raw message which is read from db into Reason.


### PR DESCRIPTION
feat(async/task): 支持 task 重试和 flow 取消

#### task 重试
 1. 要求对应flow 和task 都是失败的情况
 2. 将对应flow和task 改回pending 以重新加入调度

#### flow 取消
 1. 手动调用task server 接口后及将对应flow 的state改为 cancel
 2. 对应worker轮询该节点上状态为cancel 的flow
 3. 取到需终止flow后将flow 的worker置空，标识取消已经被接受，防止反复终止任务
 4. 终止实现逻辑为立即调用对应task cancel方法 删除worker 上的任务树

#### 对框架的修改：
 1. 修改任务状态时会保存原状态到`Reason.PreState`字段中
 2. 任务rollback 的次数会记录到`Reason.RollbackCount`字段中

 --story=116333026 异步任务-子任务重试
 --story=116333048 异步任务-终止任务