### PR TITLE
fix:缺陷修复问题

### DIFF
--- a/front/src/hooks/useTable/useTable.tsx
+++ b/front/src/hooks/useTable/useTable.tsx
@@ -306,6 +306,8 @@ export const useTable = (props: IProp) => {
     // 如果是任务类型, 则使用 json_neq
     else if (val?.id === 'detail.data.res_flow.flow_id') {
       op = QueryRuleOPEnum.JSON_NEQ;
+    } else if (val?.id === 'health_check.health_switch') {
+      op = QueryRuleOPEnum.JSON_EQ;
     }
     // 否则, 精确搜索
     else {

--- a/front/src/views/business/forms/security/index.vue
+++ b/front/src/views/business/forms/security/index.vue
@@ -49,11 +49,8 @@ const cancel = async () => {
   emit('cancel');
 };
 const submit = async () => {
-  const validate = await Promise.all([formSelectRef.value[0](), formRef.value.validate()]);
-  console.log(validate);
   const params: any = { ...formData.value, ...formFilter.value };
   if (type.value === 'aws') {
-    console.log('cloudVpcId.value', cloudVpcId.value, params.extension);
     params.extension = {
       cloud_vpc_id: cloudVpcId.value,
     };
@@ -73,7 +70,6 @@ const submit = async () => {
     });
     emit('success');
   } catch (error) {
-    console.log(error);
   } finally {
     submitLoading.value = false;
   }
@@ -117,7 +113,7 @@ const { datas, isLoading } = useQueryList(filter.value, 'vpcs'); // 只查aws的
     <form-select @change="handleFormFilter" type="security" ref="formSelectRef"></form-select>
     <bk-form class="form-subnet" label-width="150" :model="formData" :rules="rules" ref="formRef">
       <bk-form-item :label="t('名称')" class="item-warp" required property="name">
-        <bk-input class="item-warp-component" v-model="formData.name" :placeholder="t('请输入子网名称')" />
+        <bk-input class="item-warp-component" v-model="formData.name" :placeholder="t('请输入安全组名称')" />
       </bk-form-item>
 
       <bk-form-item :label="t('备注')" class="item-warp">

--- a/front/src/views/business/forms/security/index.vue
+++ b/front/src/views/business/forms/security/index.vue
@@ -49,6 +49,7 @@ const cancel = async () => {
   emit('cancel');
 };
 const submit = async () => {
+  await Promise.all([formSelectRef.value[0](), formRef.value.validate()]);
   const params: any = { ...formData.value, ...formFilter.value };
   if (type.value === 'aws') {
     params.extension = {

--- a/front/src/views/business/load-balancer/clb-view/specific-clb-manager/clb-detail/index.scss
+++ b/front/src/views/business/load-balancer/clb-view/specific-clb-manager/clb-detail/index.scss
@@ -8,6 +8,9 @@
   .ml60 {
     margin-left: 60px;
   }
+  .ml10 {
+    margin-left: 10px;
+  }
   .clb-detail-info-title {
     font-weight: 700;
     font-size: 14px;

--- a/front/src/views/business/load-balancer/clb-view/specific-clb-manager/clb-detail/index.tsx
+++ b/front/src/views/business/load-balancer/clb-view/specific-clb-manager/clb-detail/index.tsx
@@ -66,6 +66,12 @@ export default defineComponent({
               }}
             />
             <Tag theme={isProtected.value ? 'success' : ''}> {isProtected.value ? '已开启' : '未开启'} </Tag>
+            <i
+              class='hcm-icon bkhcm-icon-info-line ml10'
+              v-bk-tooltips={{
+                content: '开启删除保护后，在云控制台或调用 API 均无法删除该实例',
+                placement: 'top-end',
+              }}></i>
           </div>
         ),
       },

--- a/front/src/views/business/load-balancer/clb-view/specific-domain-manager/index.tsx
+++ b/front/src/views/business/load-balancer/clb-view/specific-domain-manager/index.tsx
@@ -95,7 +95,7 @@ export default defineComponent({
                   <Link
                     class='target-group-name-btn'
                     theme='primary'
-                    href={`/#/business/loadbalancer/group-view/${data.target_group_id}?bizs=${accountStore.bizs}&type=list`}>
+                    href={`/#/business/loadbalancer/group-view/${data.target_group_id}?bizs=${accountStore.bizs}&type=detail`}>
                     {cell || '--'}
                   </Link>
                   {/* <span class={'target-group-name-btn'}></span> */}

--- a/front/src/views/business/load-balancer/group-view/all-groups-manager/useRenderTGList.tsx
+++ b/front/src/views/business/load-balancer/group-view/all-groups-manager/useRenderTGList.tsx
@@ -53,6 +53,14 @@ export default () => {
       id: 'cloud_vpc_id',
       name: '所属VPC',
     },
+    {
+      id: 'health_check.health_switch',
+      name: '健康检查',
+      children: [
+        { name: '已开启', id: 1 },
+        { name: '未开启', id: 0 },
+      ],
+    },
   ];
   const tableColumns = [
     ...columns,
@@ -105,6 +113,14 @@ export default () => {
     requestOption: {
       type: 'target_groups',
       sortOption: { sort: 'created_at', order: 'DESC' },
+      async resolveDataListCb(dataList: any) {
+        if (dataList.length === 0) return;
+        return dataList.map((data: any) => {
+          const { health_check } = data;
+          health_check.health_switch = health_check.health_switch || 0;
+          return { ...data, health_check };
+        });
+      },
     },
   });
 

--- a/front/src/views/business/load-balancer/group-view/specific-target-group-manager/index.scss
+++ b/front/src/views/business/load-balancer/group-view/specific-target-group-manager/index.scss
@@ -52,7 +52,9 @@
         }
       }
     }
-
+    .detail-info-wrap:first-child {
+      margin-bottom: 32px;
+    }
     &:not(:last-child) {
       margin-bottom: 32px;
     }

--- a/front/src/views/resource/resource-manage/hooks/use-columns.tsx
+++ b/front/src/views/resource/resource-manage/hooks/use-columns.tsx
@@ -1163,7 +1163,9 @@ export default (type: string, isSimpleShow = false, vendor?: string) => {
       ),
     }),
     {
-      label: '负载均衡域名',
+      label: () => (
+        <span v-bk-tooltips={{ content: '用户通过该域名访问负载均衡流量', placement: 'top' }}>负载均衡域名</span>
+      ),
       field: 'domain',
       isDefaultShow: true,
       render: ({ cell }: { cell: string }) => cell || '--',

--- a/front/src/views/resource/resource-manage/hooks/use-columns.tsx
+++ b/front/src/views/resource/resource-manage/hooks/use-columns.tsx
@@ -1425,6 +1425,20 @@ export default (type: string, isSimpleShow = false, vendor?: string) => {
       sort: true,
     },
     {
+      label: '健康检查',
+      field: 'health_check.health_switch',
+      isDefaultShow: true,
+      filter: {
+        list: [
+          { value: 1, text: '已开启' },
+          { value: 0, text: '未开启' },
+        ],
+      },
+      render({ cell }: { cell: Number }) {
+        return cell ? '已开启' : '未开启';
+      },
+    },
+    {
       label: '云厂商',
       field: 'vendor',
       render({ cell }: { cell: string }) {


### PR DESCRIPTION
--bug=123786807 【必须】哪些安全组已启用了健康检查，是否可以在列表中有呈现，更便于
--bug=123786819 【必须】除了上面问题的这种禁止删除逻辑，此处的删除保护又是什么逻辑，需要的话同样需要考虑如何进行视觉表达。
--bug=123786877 【必须】负载均衡域名容易和监听器域名混淆，怎么提示下
--bug=123786881 【必须】目标组链接应该跳转到目标组成员的tab（基本信息）
--bug=123786885 【必须】新建安全组的输入框提示词错误 
--bug=123786943 【必须】信息之间间距不够