### PR TITLE
perf: 优化腾讯云证书同步性能

### DIFF
--- a/cmd/hc-service/logics/res-sync/tcloud/cert.go
+++ b/cmd/hc-service/logics/res-sync/tcloud/cert.go
@@ -41,11 +41,14 @@ import (
 	"hcm/pkg/runtime/filter"
 	"hcm/pkg/tools/assert"
 	"hcm/pkg/tools/converter"
+	"hcm/pkg/tools/slice"
 )
 
 // SyncCertOption ...
 type SyncCertOption struct {
 	BkBizID int64 `json:"bk_biz_id" validate:"omitempty"`
+	// should match params' cloud id
+	PreCachedCertList []typecert.TCloudCert
 }
 
 // Validate ...
@@ -58,22 +61,19 @@ func (cli *client) Cert(kt *kit.Kit, params *SyncBaseParams, opt *SyncCertOption
 	if err := validator.ValidateTool(params, opt); err != nil {
 		return nil, errf.NewFromErr(errf.InvalidParameter, err)
 	}
-
-	certFromCloud, err := cli.listCertFromCloud(kt, params)
-	if err != nil {
-		return nil, err
+	certFromCloud := opt.PreCachedCertList
+	if certFromCloud == nil {
+		var err error
+		certFromCloud, err = cli.listCertFromCloud(kt, params)
+		if err != nil {
+			return nil, err
+		}
 	}
-
-	logs.Infof("[%s] hcservice sync cert listCertFromCloud success, params: %+v, cloud_cert_count: %d, rid: %s",
-		enumor.TCloud, params, len(certFromCloud), kt.Rid)
 
 	certFromDB, err := cli.listCertFromDB(kt, params)
 	if err != nil {
 		return nil, err
 	}
-
-	logs.Infof("[%s] hcservice sync cert listCertFromDB success, db_cert_count: %d, rid: %s",
-		enumor.TCloud, len(certFromDB), kt.Rid)
 
 	if len(certFromCloud) == 0 && len(certFromDB) == 0 {
 		return new(SyncResult), nil
@@ -82,25 +82,16 @@ func (cli *client) Cert(kt *kit.Kit, params *SyncBaseParams, opt *SyncCertOption
 	addSlice, updateMap, delCloudIDs := common.Diff[typecert.TCloudCert, *corecert.Cert[corecert.TCloudCertExtension]](
 		certFromCloud, certFromDB, isCertChange)
 
-	logs.Infof("[%s] hcservice sync cert diff success, addNum: %d, updateNum: %d, delNum: %d, rid: %s",
-		enumor.TCloud, len(addSlice), len(updateMap), len(delCloudIDs), kt.Rid)
-
-	if len(delCloudIDs) > 0 {
-		if err = cli.deleteCert(kt, params.AccountID, params.Region, delCloudIDs); err != nil {
-			return nil, err
-		}
+	if err = cli.deleteCert(kt, params.AccountID, params.Region, delCloudIDs); err != nil {
+		return nil, err
 	}
 
-	if len(addSlice) > 0 {
-		if err = cli.createCert(kt, params.AccountID, opt, addSlice); err != nil {
-			return nil, err
-		}
+	if err = cli.createCert(kt, params.AccountID, opt, addSlice); err != nil {
+		return nil, err
 	}
 
-	if len(updateMap) > 0 {
-		if err = cli.updateCert(kt, params.AccountID, updateMap); err != nil {
-			return nil, err
-		}
+	if err = cli.updateCert(kt, params.AccountID, updateMap); err != nil {
+		return nil, err
 	}
 
 	return new(SyncResult), nil
@@ -108,43 +99,24 @@ func (cli *client) Cert(kt *kit.Kit, params *SyncBaseParams, opt *SyncCertOption
 
 func (cli *client) deleteCert(kt *kit.Kit, accountID, region string, delCloudIDs []string) error {
 	if len(delCloudIDs) <= 0 {
-		return fmt.Errorf("hcservice resource sync failed, delCloudIDs is <= 0, not delete")
-	}
-
-	checkParams := &SyncBaseParams{
-		AccountID: accountID,
-		Region:    region,
-		CloudIDs:  delCloudIDs,
-	}
-	delFromCloud, err := cli.listCertFromCloud(kt, checkParams)
-	if err != nil {
-		return err
-	}
-
-	if len(delFromCloud) > 0 {
-		logs.Errorf("[%s] validate cert not exist failed, before delete, opt: %v, failed_count: %d, rid: %s",
-			enumor.TCloud, checkParams, len(delFromCloud), kt.Rid)
-		return fmt.Errorf("validate cert not exist failed, before delete")
+		return nil
 	}
 
 	deleteReq := &protocloud.CertBatchDeleteReq{
 		Filter: tools.ContainersExpression("cloud_id", delCloudIDs),
 	}
-	if err = cli.dbCli.Global.BatchDeleteCert(kt.Ctx, kt.Header(), deleteReq); err != nil {
-		logs.Errorf("[%s] request dataservice to batch delete cert failed, err: %v, rid: %s", enumor.TCloud,
-			err, kt.Rid)
+	if err := cli.dbCli.Global.BatchDeleteCert(kt.Ctx, kt.Header(), deleteReq); err != nil {
+		logs.Errorf("[%s] request dataservice to batch delete cert failed, err: %v, rid: %s",
+			enumor.TCloud, err, kt.Rid)
 		return err
 	}
-
-	logs.Infof("[%s] sync cert to delete cert success, accountID: %s, count: %d, rid: %s", enumor.TCloud,
-		accountID, len(delCloudIDs), kt.Rid)
 
 	return nil
 }
 
 func (cli *client) updateCert(kt *kit.Kit, accountID string, updateMap map[string]typecert.TCloudCert) error {
 	if len(updateMap) <= 0 {
-		return fmt.Errorf("hcservice resource sync failed, updateMap is <= 0, not update")
+		return nil
 	}
 
 	certs := make([]*protocloud.CertExtUpdateReq[corecert.TCloudCertExtension], 0)
@@ -187,9 +159,11 @@ func (cli *client) updateCert(kt *kit.Kit, accountID string, updateMap map[strin
 	return nil
 }
 
-func (cli *client) createCert(kt *kit.Kit, accountID string, opt *SyncCertOption, addSlice []typecert.TCloudCert) error {
+func (cli *client) createCert(kt *kit.Kit, accountID string, opt *SyncCertOption,
+	addSlice []typecert.TCloudCert) error {
+
 	if len(addSlice) <= 0 {
-		return fmt.Errorf("hcservice resource sync failed, addSlice is <= 0, not create")
+		return nil
 	}
 
 	var createReq = new(protocloud.CertBatchCreateReq[corecert.TCloudCertExtension])
@@ -219,17 +193,41 @@ func (cli *client) createCert(kt *kit.Kit, accountID string, opt *SyncCertOption
 		createReq.Certs = append(createReq.Certs, cert...)
 	}
 
-	newIDs, err := cli.dbCli.TCloud.BatchCreateCert(kt.Ctx, kt.Header(), createReq)
+	_, err := cli.dbCli.TCloud.BatchCreateCert(kt.Ctx, kt.Header(), createReq)
 	if err != nil {
 		logs.Errorf("[%s] request dataservice to create tcloud cert failed, createReq: %+v, err: %v, rid: %s",
 			enumor.TCloud, createReq, err, kt.Rid)
 		return err
 	}
 
-	logs.Infof("[%s] sync cert to create cert success, accountID: %s, count: %d, newIDs: %v, opt: %+v, rid: %s", enumor.TCloud,
-		accountID, len(addSlice), newIDs, opt, kt.Rid)
-
 	return nil
+}
+
+// 不支持按id批量获取，直接获取全部数据可以降低调用腾讯云api次数
+func (cli *client) listAllCertFromCloud(kt *kit.Kit) ([]typecert.TCloudCert, error) {
+
+	list := make([]typecert.TCloudCert, 0, 100)
+	opt := &typecert.TCloudListOption{
+		Page: &adcore.TCloudPage{Offset: 0, Limit: adcore.TCloudQueryLimit},
+	}
+	for {
+		result, err := cli.cloudCli.ListCert(kt, opt)
+		if err != nil {
+			logs.Errorf("[%s] list all cert from cloud failed, account: %s, opt: %v, err: %v, rid: %s",
+				enumor.TCloud, cli.accountID, opt, err, kt.Rid)
+			return nil, err
+		}
+
+		list = append(list, result...)
+
+		if uint64(len(result)) < opt.Page.Limit {
+			break
+		}
+		opt.Page.Offset += opt.Page.Limit
+
+	}
+
+	return list, nil
 }
 
 func (cli *client) listCertFromCloud(kt *kit.Kit, params *SyncBaseParams) ([]typecert.TCloudCert, error) {
@@ -350,6 +348,16 @@ func (cli *client) RemoveCertDeleteFromCloud(kt *kit.Kit, accountID, region stri
 			Limit: constant.BatchOperationMaxLimit,
 		},
 	}
+	// 全量获取一次云端证书数据
+	allResultFromCloud, err := cli.listAllCertFromCloud(kt)
+	certCloudIDMap := make(map[string]struct{}, len(allResultFromCloud))
+	for _, cert := range allResultFromCloud {
+		certCloudIDMap[cert.GetCloudID()] = struct{}{}
+	}
+	if err != nil {
+		return err
+	}
+	delCloudIDs := make([]string, 0)
 	for {
 		resultFromDB, err := cli.dbCli.Global.ListCert(kt, req)
 		if err != nil {
@@ -357,36 +365,9 @@ func (cli *client) RemoveCertDeleteFromCloud(kt *kit.Kit, accountID, region stri
 				enumor.TCloud, req, err, kt.Rid)
 			return err
 		}
-
-		cloudIDs := make([]string, 0)
-		for _, one := range resultFromDB.Details {
-			cloudIDs = append(cloudIDs, one.CloudID)
-		}
-
-		if len(cloudIDs) == 0 {
-			break
-		}
-
-		params := &SyncBaseParams{
-			AccountID: accountID,
-			Region:    region,
-			CloudIDs:  cloudIDs,
-		}
-		resultFromCloud, err := cli.listCertFromCloud(kt, params)
-		if err != nil {
-			return err
-		}
-
-		// 如果有资源没有查询出来，说明数据被从云上删除
-		if len(resultFromCloud) != len(cloudIDs) {
-			cloudIDMap := converter.StringSliceToMap(cloudIDs)
-			for _, one := range resultFromCloud {
-				delete(cloudIDMap, converter.PtrToVal(one.CertificateId))
-			}
-
-			cloudIDs = converter.MapKeyToStringSlice(cloudIDMap)
-			if err = cli.deleteCert(kt, accountID, region, cloudIDs); err != nil {
-				return err
+		for _, detail := range resultFromDB.Details {
+			if _, ok := certCloudIDMap[detail.CloudID]; !ok {
+				delCloudIDs = append(delCloudIDs, detail.CloudID)
 			}
 		}
 
@@ -395,6 +376,16 @@ func (cli *client) RemoveCertDeleteFromCloud(kt *kit.Kit, accountID, region stri
 		}
 
 		req.Page.Start += constant.BatchOperationMaxLimit
+	}
+	if len(delCloudIDs) == 0 {
+		return nil
+	}
+
+	for _, delCloudBatch := range slice.Split(delCloudIDs, constant.BatchOperationMaxLimit) {
+		if err = cli.deleteCert(kt, accountID, region, delCloudBatch); err != nil {
+			return err
+		}
+
 	}
 
 	return nil

--- a/pkg/api/data-service/cloud/cert.go
+++ b/pkg/api/data-service/cloud/cert.go
@@ -42,7 +42,7 @@ type CertBatchCreateReq[Extension corecert.Extension] struct {
 // CertBatchCreate define cert batch create.
 type CertBatchCreate[Extension corecert.Extension] struct {
 	CloudID          string          `json:"cloud_id" validate:"required"`
-	Name             string          `json:"name" validate:"required"`
+	Name             string          `json:"name"`
 	Vendor           string          `json:"vendor" validate:"required"`
 	AccountID        string          `json:"account_id" validate:"required"`
 	BkBizID          int64           `json:"bk_biz_id" validate:"omitempty"`

--- a/pkg/dal/table/cloud/cert/cert.go
+++ b/pkg/dal/table/cloud/cert/cert.go
@@ -102,10 +102,6 @@ func (v SslCertTable) InsertValidate() error {
 		return errors.New("cloud id can not be empty")
 	}
 
-	if len(v.Name) == 0 {
-		return errors.New("name can not be nil")
-	}
-
 	if len(v.Vendor) == 0 {
 		return errors.New("vendor can not be empty")
 	}

--- a/scripts/sql/9999_cross_region_rs.sql
+++ b/scripts/sql/9999_cross_region_rs.sql
@@ -18,21 +18,23 @@
  */
 
 
-
 /*
     SQLVER=9999,HCMVER=v9.9.9
 
     Notes:
-    1. 修改rs表:增加ip, 以 cloud_target_group_id,ip,port 为唯一键
+    1. 修改`load_balancer_target`表: 增加ip, 以 `cloud_target_group_id`,`ip`,`port` 为唯一键
+    2. 修改`target_group_listener_rule_rel`表，增加`vendor`字段
+    3. 修改`ssl_cert`表，`cloud_created_time`,`cloud_expired_time`字段类型为`varchar(32)`
 */
 
 START TRANSACTION;
 
 /* first use default value from private_ip_address*/
 alter table load_balancer_target
-    add ip varchar(255) not null default (private_ip_address->>'$[0]') not null after inst_type;
+    add ip varchar(255) not null default (private_ip_address ->> '$[0]') not null after inst_type;
 /* second remove default value definition */
-alter table load_balancer_target modify ip varchar(255) not null default '';
+alter table load_balancer_target
+    modify ip varchar(255) not null default '';
 
 
 alter table load_balancer_target
@@ -42,8 +44,17 @@ alter table load_balancer_target
     add constraint idx_uk_cloud_target_group_id_ip_port_cloud_inst_id
         unique (cloud_target_group_id, ip, port, cloud_inst_id);
 
-alter table target_group_listener_rule_rel add vendor varchar(16)  default 'tcloud' not null after id;
-alter table target_group_listener_rule_rel modify vendor varchar(16) not null default '';
+alter table target_group_listener_rule_rel
+    add vendor varchar(16) default 'tcloud' not null after id;
+alter table target_group_listener_rule_rel
+    modify vendor varchar(16) not null default '';
+
+alter table ssl_cert
+    modify cloud_created_time varchar(32) default '' not null;
+
+alter table ssl_cert
+    modify cloud_expired_time varchar(32) default '' not null;
+
 
 CREATE OR REPLACE VIEW `hcm_version`(`hcm_ver`, `sql_ver`) AS
 SELECT 'v9.9.9' as `hcm_ver`, '9999' as `sql_ver`;


### PR DESCRIPTION
1. 批量获取腾讯云证书
2. 允许证书名为空
3. 修改数据库证书过期时间字段类型为varchar(32)，支持2038

腾讯云证书接口不支持按id批量获取，原方式需要频繁调用api，账号下证书稍微多一些就会消耗很多时间在请求云API上。
这里改成一次批量获取全部，并在比较方法中复用Next方法获取的证书实例，避免二次请求云API。