### PR TITLE
feat: 增加对异步请求云接口的限流重试支持 story=117465236

### DIFF
--- a/cmd/hc-service/logics/cloud-adaptor/cloud_client.go
+++ b/cmd/hc-service/logics/cloud-adaptor/cloud_client.go
@@ -27,6 +27,7 @@ import (
 	"hcm/pkg/adaptor/huawei"
 	"hcm/pkg/adaptor/tcloud"
 	dataservice "hcm/pkg/client/data-service"
+	"hcm/pkg/criteria/enumor"
 	"hcm/pkg/kit"
 )
 
@@ -56,7 +57,9 @@ func (cli *CloudAdaptorClient) TCloud(kt *kit.Kit, accountID string) (tcloud.TCl
 		return nil, err
 	}
 
-	return cli.adaptor.TCloud(secret)
+	client, err := cli.adaptor.TCloud(secret)
+	client.WithRateLimitExceededRetryable(kt.RequestSource == enumor.AsynchronousTasks)
+	return client, err
 }
 
 // Aws return aws client.

--- a/pkg/adaptor/tcloud/client.go
+++ b/pkg/adaptor/tcloud/client.go
@@ -21,6 +21,7 @@ package tcloud
 
 import (
 	"hcm/pkg/adaptor/types"
+	"time"
 
 	billing "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/billing/v20180709"
 	cam "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cam/v20190116"
@@ -40,6 +41,7 @@ const (
 
 // ClientSet interface to get tcloud sdk client set
 type ClientSet interface {
+	SetRateLimitExceededRetry(int, time.Duration)
 	CamServiceClient(region string) (*cam.Client, error)
 	CvmClient(region string) (*cvm.Client, error)
 	CbsClient(region string) (*cbs.Client, error)
@@ -60,6 +62,12 @@ func newClientSet(s *types.BaseSecret, profile *profile.ClientProfile) ClientSet
 		credential: common.NewCredential(s.CloudSecretID, s.CloudSecretKey),
 		profile:    profile,
 	}
+}
+
+// SetRateLimitExceededRetry Set up a retry mechanism after exceeding the rate limit
+func (c *clientSet) SetRateLimitExceededRetry(maxRetries int, interval time.Duration) {
+	c.profile.RateLimitExceededMaxRetries = maxRetries
+	c.profile.RateLimitExceededRetryDuration = profile.ConstantDurationFunc(interval)
 }
 
 // CamServiceClient tcloud sdk cam client

--- a/pkg/adaptor/tcloud/interface.go
+++ b/pkg/adaptor/tcloud/interface.go
@@ -52,6 +52,7 @@ import (
 
 // TCloud adaptor interface for tencent cloud
 type TCloud interface {
+	WithRateLimitExceededRetryable(retryable bool)
 	ListImage(kt *kit.Kit,
 		opt *image.TCloudImageListOption) (*image.TCloudImageListResult, error)
 	CreateSubnet(kt *kit.Kit, opt *adtysubnet.TCloudSubnetCreateOption) (*adtysubnet.TCloudSubnet,

--- a/pkg/adaptor/tcloud/tcloud.go
+++ b/pkg/adaptor/tcloud/tcloud.go
@@ -23,6 +23,8 @@ package tcloud
 import (
 	"hcm/pkg/adaptor/types"
 	"hcm/pkg/criteria/errf"
+	"math/rand"
+	"time"
 
 	"github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/profile"
 )
@@ -57,4 +59,18 @@ func validateSecret(s *types.BaseSecret) error {
 	}
 
 	return nil
+}
+
+// WithRateLimitExceededRetryable determine whether to set the retry parameter after exceeding the rate limit
+func (t *TCloudImpl) WithRateLimitExceededRetryable(retryable bool) {
+	if retryable {
+		maxRetries := 1000
+		minRetryInterval := 100
+		maxRetryInterval := 500
+		rand.Seed(time.Now().UnixNano())
+		randomSec := rand.Intn(maxRetryInterval-minRetryInterval+1) + minRetryInterval
+		interval := time.Duration(randomSec) * time.Millisecond
+
+		t.clientSet.SetRateLimitExceededRetry(maxRetries, interval)
+	}
 }

--- a/pkg/criteria/enumor/enumor.go
+++ b/pkg/criteria/enumor/enumor.go
@@ -38,6 +38,8 @@ const (
 	ApiCall RequestSourceType = "api_call"
 	// BackgroundSync 同步云上数据而发出的请求。
 	BackgroundSync RequestSourceType = "background_sync"
+	// AsynchronousTasks 异步任务请求，比如云的批量异步操作，会设置腾讯云接口调用的超限重试
+	AsynchronousTasks RequestSourceType = "asynchronous_tasks"
 )
 
 // RequestSourceEnums request type map.


### PR DESCRIPTION
- 海垒云接口调用限流需求