### PR TITLE
feat: TCloud CVM创建支持计费模式和带宽包id参数

### DIFF
--- a/cmd/cloud-server/service/application/handlers/cvm/tcloud/constants.go
+++ b/cmd/cloud-server/service/application/handlers/cvm/tcloud/constants.go
@@ -51,4 +51,11 @@ var (
 		typecvm.Spotpaid:       "竞价付费",
 		typecvm.Cdcpaid:        "专用集群付费",
 	}
+	// InternetChargeTypeNameMap TCloud cvm internet charge type
+	InternetChargeTypeNameMap = map[typecvm.TCloudInternetChargeType]string{
+		typecvm.TCloudInternetBandwidthPrepaid:        "预付费按带宽结算",
+		typecvm.TCloudInternetBandwidthPackage:        "带宽包用户",
+		typecvm.TCloudInternetTrafficPostpaidByHour:   "流量按小时后付费",
+		typecvm.TCloudInternetBandwidthPostpaidByHour: "带宽按小时后付费",
+	}
 )

--- a/cmd/cloud-server/service/application/handlers/cvm/tcloud/create_itsm_ticket.go
+++ b/cmd/cloud-server/service/application/handlers/cvm/tcloud/create_itsm_ticket.go
@@ -23,6 +23,9 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+
+	typescvm "hcm/pkg/adaptor/types/cvm"
+	cvt "hcm/pkg/tools/converter"
 )
 
 type formItem struct {
@@ -159,9 +162,19 @@ func (a *ApplicationOfCreateTCloudCvm) renderNetwork() ([]formItem, error) {
 	if req.PublicIPAssigned {
 		formItems = append(formItems, formItem{Label: "是否自动分配公网IP", Value: "是"})
 		formItems = append(formItems, formItem{Label: "EIP带宽大小", Value: strconv.FormatInt(
-			a.req.InternetMaxBandwidthOut, 64)})
+			a.req.InternetMaxBandwidthOut, 10)})
 	} else {
 		formItems = append(formItems, formItem{Label: "是否自动分配公网IP", Value: "否"})
+	}
+	if len(req.InternetChargeType) > 0 {
+		internetChargeType, ok := InternetChargeTypeNameMap[req.InternetChargeType]
+		if !ok {
+			internetChargeType = string(req.InternetChargeType)
+		}
+		formItems = append(formItems, formItem{Label: "网络计费模式", Value: internetChargeType})
+		if req.InternetChargeType == typescvm.TCloudInternetBandwidthPackage {
+			formItems = append(formItems, formItem{Label: "带宽包ID", Value: cvt.PtrToVal(req.BandwidthPackageID)})
+		}
 	}
 
 	// 所属的蓝鲸云区域

--- a/cmd/cloud-server/service/application/handlers/cvm/wait_deliver_cvm.go
+++ b/cmd/cloud-server/service/application/handlers/cvm/wait_deliver_cvm.go
@@ -205,7 +205,7 @@ func queryAndParseEndStateFlowByFlowID(kt *kit.Kit, cli *taskserver.Client, flow
 	flowResultMap := make(map[string]*hccvm.BatchCreateResult)
 	for _, task := range tasks {
 		tmp := new(hccvm.BatchCreateResult)
-		if err := json.UnmarshalFromString(string(task.Result), &tmp); err != nil {
+		if err := json.UnmarshalFromString(string(task.Result), tmp); err != nil {
 			logs.Errorf("unmarshal tasks result failed, err: %v, rid: %s", err, kt.Rid)
 			return nil, err
 		}

--- a/cmd/cloud-server/service/common/conv.go
+++ b/cmd/cloud-server/service/common/conv.go
@@ -78,6 +78,8 @@ func ConvTCloudCvmCreateReq(req *cscvm.TCloudCvmCreateReq) *hcproto.TCloudBatchC
 		DataDisk:                dataDisk,
 		PublicIPAssigned:        req.PublicIPAssigned,
 		InternetMaxBandwidthOut: req.InternetMaxBandwidthOut,
+		InternetChargeType:      req.InternetChargeType,
+		BandwidthPackageID:      req.BandwidthPackageID,
 	}
 
 	return createReq

--- a/cmd/hc-service/service/cvm/tcloud.go
+++ b/cmd/hc-service/service/cvm/tcloud.go
@@ -83,6 +83,8 @@ func (svc *cvmSvc) InquiryPriceTCloudCvm(cts *rest.Contexts) (interface{}, error
 		DataDisk:                req.DataDisk,
 		PublicIPAssigned:        req.PublicIPAssigned,
 		InternetMaxBandwidthOut: req.InternetMaxBandwidthOut,
+		InternetChargeType:      req.InternetChargeType,
+		BandwidthPackageID:      req.BandwidthPackageID,
 	}
 	result, err := tcloud.InquiryPriceCvm(cts.Kit, createOpt)
 	if err != nil {

--- a/cmd/hc-service/service/cvm/tcloud.go
+++ b/cmd/hc-service/service/cvm/tcloud.go
@@ -128,6 +128,8 @@ func (svc *cvmSvc) BatchCreateTCloudCvm(cts *rest.Contexts) (interface{}, error)
 		DataDisk:                req.DataDisk,
 		PublicIPAssigned:        req.PublicIPAssigned,
 		InternetMaxBandwidthOut: req.InternetMaxBandwidthOut,
+		InternetChargeType:      req.InternetChargeType,
+		BandwidthPackageID:      req.BandwidthPackageID,
 	}
 	result, err := tcloud.CreateCvm(cts.Kit, createOpt)
 	if err != nil {

--- a/docs/api-docs/web-server/docs/resource/create_application_for_create_tcloud_cvm.md
+++ b/docs/api-docs/web-server/docs/resource/create_application_for_create_tcloud_cvm.md
@@ -29,11 +29,24 @@ POST /api/v1/cloud/vendors/tcloud/applications/types/create_cvm
 | password                    | string        | 是  | 密码                                                                                                                   |
 | confirmed_password          | string        | 是  | 确认密码                                                                                                                 |
 | instance_charge_type        | string        | 是  | 实例计费模式（PREPAID：表示预付费，即包年包月、POSTPAID_BY_HOUR：表示后付费，即按量计费、CDHPAID：专用宿主机付费，即只对专用宿主机计费，不对专用宿主机上的实例计费。、SPOTPAID：表示竞价实例付费） |
+| internet_charge_type        | string        | 否  | (9.9.9+)网络计费类型，见下文。                                                                                                  |
+| bandwidth_package_id        | string        | 否  | (9.9.9+)带宽包id                                                                                                        |
 | instance_charge_paid_period | int64         | 是  | 实例计费支付周期                                                                                                             |
 | auto_renew                  | bool          | 是  | 是否自动续订                                                                                                               |
 | required_count              | int64         | 是  | 需要数量                                                                                                                 |
 | memo                        | string        | 否  | 备注                                                                                                                   |
 | remark                      | string        | 否  | 单据备注                                                                                                                 |
+
+#### internet_charge_type 网络计费类型 取值范围
+
+- BANDWIDTH_PREPAID：预付费按带宽结算
+- TRAFFIC_POSTPAID_BY_HOUR：流量按小时后付费
+- BANDWIDTH_POSTPAID_BY_HOUR：带宽按小时后付费
+- BANDWIDTH_PACKAGE：带宽包用户
+
+##### internet_charge_type 默认取值：
+
+非带宽包用户默认与子机付费类型保持一致，比如子机付费类型为预付费，网络计费类型默认为预付费；子机付费类型为后付费，网络计费类型默认为后付费。
 
 #### system_disk
 

--- a/docs/api-docs/web-server/docs/resource/create_cvm.md
+++ b/docs/api-docs/web-server/docs/resource/create_cvm.md
@@ -30,9 +30,22 @@ POST /api/v1/cloud/cvms/create
 | confirmed_password          | string        | 是  | 确认密码                                                                                                                 |
 | instance_charge_type        | string        | 是  | 实例计费模式（PREPAID：表示预付费，即包年包月、POSTPAID_BY_HOUR：表示后付费，即按量计费、CDHPAID：专用宿主机付费，即只对专用宿主机计费，不对专用宿主机上的实例计费。、SPOTPAID：表示竞价实例付费） |
 | instance_charge_paid_period | int64         | 是  | 实例计费支付周期                                                                                                             |
+| internet_charge_type        | string        | 否  | (9.9.9+) 网络计费类型，见下文。                                                                                                 |
+| bandwidth_package_id        | string        | 否  | (9.9.9+) 带宽包id                                                                                                       |
 | auto_renew                  | bool          | 是  | 是否自动续订                                                                                                               |
 | required_count              | int64         | 是  | 需要数量                                                                                                                 |
 | memo                        | string        | 否  | 备注                                                                                                                   |
+
+#### internet_charge_type 网络计费类型 取值范围
+
+- BANDWIDTH_PREPAID：预付费按带宽结算
+- TRAFFIC_POSTPAID_BY_HOUR：流量按小时后付费
+- BANDWIDTH_POSTPAID_BY_HOUR：带宽按小时后付费
+- BANDWIDTH_PACKAGE：带宽包用户
+
+##### internet_charge_type 默认取值：
+
+非带宽包用户默认与子机付费类型保持一致，比如子机付费类型为预付费，网络计费类型默认为预付费；子机付费类型为后付费，网络计费类型默认为后付费。
 
 #### system_disk
 

--- a/docs/api-docs/web-server/docs/resource/inquiry_price_cvm.md
+++ b/docs/api-docs/web-server/docs/resource/inquiry_price_cvm.md
@@ -30,9 +30,22 @@ POST /api/v1/cloud/cvms/prices/inquiry
 | confirmed_password          | string        | 是  | 确认密码                                                                                                                 |
 | instance_charge_type        | string        | 是  | 实例计费模式（PREPAID：表示预付费，即包年包月、POSTPAID_BY_HOUR：表示后付费，即按量计费、CDHPAID：专用宿主机付费，即只对专用宿主机计费，不对专用宿主机上的实例计费。、SPOTPAID：表示竞价实例付费） |
 | instance_charge_paid_period | int64         | 是  | 实例计费支付周期                                                                                                             |
+| internet_charge_type        | string        | 否  | (9.9.9+)网络计费类型，见下文。                                                                                                  |
+| bandwidth_package_id        | string        | 否  | (9.9.9+)带宽包id                                                                                                        |
 | auto_renew                  | bool          | 是  | 是否自动续订                                                                                                               |
 | required_count              | int64         | 是  | 需要数量                                                                                                                 |
 | memo                        | string        | 否  | 备注                                                                                                                   |
+
+#### internet_charge_type 网络计费类型 取值范围
+
+- BANDWIDTH_PREPAID：预付费按带宽结算
+- TRAFFIC_POSTPAID_BY_HOUR：流量按小时后付费
+- BANDWIDTH_POSTPAID_BY_HOUR：带宽按小时后付费
+- BANDWIDTH_PACKAGE：带宽包用户
+
+##### internet_charge_type 默认取值：
+
+非带宽包用户默认与子机付费类型保持一致，比如子机付费类型为预付费，网络计费类型默认为预付费；子机付费类型为后付费，网络计费类型默认为后付费。
 
 #### system_disk
 

--- a/pkg/adaptor/tcloud/cvm.go
+++ b/pkg/adaptor/tcloud/cvm.go
@@ -377,6 +377,10 @@ func (t *TCloudImpl) CreateCvm(kt *kit.Kit, opt *typecvm.TCloudCreateOption) (*p
 	req.InternetAccessible = &cvm.InternetAccessible{
 		InternetMaxBandwidthOut: common.Int64Ptr(opt.InternetMaxBandwidthOut),
 		PublicIpAssigned:        common.BoolPtr(opt.PublicIPAssigned),
+		BandwidthPackageId:      opt.BandwidthPackageID,
+	}
+	if len(opt.InternetChargeType) != 0 {
+		req.InternetAccessible.InternetChargeType = converter.ValToPtr(string(opt.InternetChargeType))
 	}
 
 	req.SystemDisk = &cvm.SystemDisk{

--- a/pkg/adaptor/tcloud/cvm.go
+++ b/pkg/adaptor/tcloud/cvm.go
@@ -477,8 +477,11 @@ func (t *TCloudImpl) InquiryPriceCvm(kt *kit.Kit, opt *typecvm.TCloudCreateOptio
 	req.InternetAccessible = &cvm.InternetAccessible{
 		PublicIpAssigned:        common.BoolPtr(opt.PublicIPAssigned),
 		InternetMaxBandwidthOut: common.Int64Ptr(opt.InternetMaxBandwidthOut),
+		BandwidthPackageId:      opt.BandwidthPackageID,
 	}
-
+	if len(opt.InternetChargeType) != 0 {
+		req.InternetAccessible.InternetChargeType = converter.ValToPtr(string(opt.InternetChargeType))
+	}
 	req.SystemDisk = &cvm.SystemDisk{
 		DiskId:   opt.SystemDisk.CloudDiskID,
 		DiskSize: opt.SystemDisk.DiskSizeGB,

--- a/pkg/adaptor/types/cvm/tcloud.go
+++ b/pkg/adaptor/types/cvm/tcloud.go
@@ -159,6 +159,23 @@ func (opt TCloudResetPwdOption) Validate() error {
 }
 
 // -------------------------- Create --------------------------
+//
+
+// TCloudInternetChargeType CVM网络计费类型.
+// 默认取值：非带宽包用户默认与子机付费类型保持一致，比如子机付费类型为预付费，网络计费类型默认为预付费；
+// 子机付费类型为后付费，网络计费类型默认为后付费
+type TCloudInternetChargeType string
+
+const (
+	// TCloudInternetBandwidthPrepaid BANDWIDTH_PREPAID 预付费按带宽结算
+	TCloudInternetBandwidthPrepaid TCloudInternetChargeType = "BANDWIDTH_PREPAID"
+	// TCloudInternetTrafficPostpaidByHour TRAFFIC_POSTPAID_BY_HOUR 流量按小时后付费
+	TCloudInternetTrafficPostpaidByHour TCloudInternetChargeType = "TRAFFIC_POSTPAID_BY_HOUR"
+	// TCloudInternetBandwidthPostpaidByHour BANDWIDTH_POSTPAID_BY_HOUR 带宽按小时后付费
+	TCloudInternetBandwidthPostpaidByHour TCloudInternetChargeType = "BANDWIDTH_POSTPAID_BY_HOUR"
+	// TCloudInternetBandwidthPackage BANDWIDTH_PACKAGE 带宽包用户
+	TCloudInternetBandwidthPackage TCloudInternetChargeType = "BANDWIDTH_PACKAGE"
+)
 
 // TCloudCreateOption defines options to create aws cvm instances.
 type TCloudCreateOption struct {
@@ -180,6 +197,8 @@ type TCloudCreateOption struct {
 	DataDisk                []TCloudDataDisk             `json:"data_disk" validate:"omitempty"`
 	PublicIPAssigned        bool                         `json:"public_ip_assigned" validate:"omitempty"`
 	InternetMaxBandwidthOut int64                        `json:"internet_max_bandwidth_out" validate:"omitempty"`
+	InternetChargeType      TCloudInternetChargeType     `json:"internet_charge_type" validate:"omitempty"`
+	BandwidthPackageID      *string                      `json:"bandwidth_package_id" validate:"omitempty"`
 }
 
 // Validate aws cvm operation option.

--- a/pkg/api/cloud-server/cvm/create_tcloud_cvm.go
+++ b/pkg/api/cloud-server/cvm/create_tcloud_cvm.go
@@ -77,6 +77,9 @@ type TCloudCvmCreateReq struct {
 	AutoRenew                *bool `json:"auto_renew" validate:"required"`
 	RequiredCount            int64 `json:"required_count" validate:"required,min=1,max=500"`
 
+	InternetChargeType typecvm.TCloudInternetChargeType `json:"internet_charge_type" validate:"omitempty"`
+	BandwidthPackageID *string                          `json:"bandwidth_package_id" validate:"omitempty"`
+
 	Memo *string `json:"memo" validate:"omitempty"`
 }
 

--- a/pkg/api/core/cloud/cvm/tcloud.go
+++ b/pkg/api/core/cloud/cvm/tcloud.go
@@ -68,7 +68,8 @@ type TCloudCvmExtension struct {
 		- TRUE：表示开启实例保护，不允许通过api接口删除实例
 		- FALSE：表示关闭实例保护，允许通过api接口删除实例
 	*/
-	DisableApiTermination *bool `json:"disable_api_termination,omitempty"`
+	DisableApiTermination *bool   `json:"disable_api_termination,omitempty"`
+	BandwidthPackageID    *string `json:"bandwidth_package_id,omitempty"`
 }
 
 // TCloudPlacement 描述了实例的抽象位置，包括其所在的可用区，所属的项目，宿主机（仅专用宿主机产品可用），母机IP等。

--- a/pkg/api/hc-service/cvm/tcloud.go
+++ b/pkg/api/hc-service/cvm/tcloud.go
@@ -135,6 +135,8 @@ type TCloudBatchCreateReq struct {
 	DataDisk                []typecvm.TCloudDataDisk             `json:"data_disk" validate:"omitempty"`
 	PublicIPAssigned        bool                                 `json:"public_ip_assigned" validate:"omitempty"`
 	InternetMaxBandwidthOut int64                                `json:"internet_max_bandwidth_out" validate:"omitempty"`
+	InternetChargeType      typecvm.TCloudInternetChargeType     `json:"internet_charge_type" validate:"omitempty"`
+	BandwidthPackageID      *string                              `json:"bandwidth_package_id" validate:"omitempty"`
 }
 
 // Validate request.


### PR DESCRIPTION
CreateCvm 增加了对下列参数的支持：
- `internet_charge_type`
- `bandwidth_package_id`

--story=119803607