### PR TITLE
feat: 批量任务Action创建4层7层监听器、7层规则、绑定RS，支持部分指定负载均衡/监听器ID同步

### DIFF
--- a/cmd/cloud-server/service/load-balancer/create.go
+++ b/cmd/cloud-server/service/load-balancer/create.go
@@ -259,7 +259,7 @@ func (svc *lbSvc) batchCreateTCloudListener(kt *kit.Kit, rawReq json.RawMessage,
 
 	req.BkBizID = bkBizID
 	req.LbID = lbID
-	createResp, err := svc.client.HCService().TCloud.Clb.CreateListener(kt, req)
+	createResp, err := svc.client.HCService().TCloud.Clb.CreateListenerWithTargetGroup(kt, req)
 	if err != nil {
 		logs.Errorf("fail to create tcloud url rule, err: %v, req: %+v, cert: %+v, rid: %s",
 			err, req, cvt.PtrToVal(req.Certificate), kt.Rid)

--- a/cmd/hc-service/logics/res-sync/tcloud/client.go
+++ b/cmd/hc-service/logics/res-sync/tcloud/client.go
@@ -77,13 +77,14 @@ type Interface interface {
 	RemoveCertDeleteFromCloud(kt *kit.Kit, accountID string, region string) error
 
 	LoadBalancer(kt *kit.Kit, params *SyncBaseParams, opt *SyncLBOption) (*SyncResult, error)
-	RemoveLoadBalancerDeleteFromCloud(kt *kit.Kit, accountID string, region string) error
+	RemoveLoadBalancerDeleteFromCloud(kt *kit.Kit, params *SyncRemovedParams) error
 
 	// LoadBalancerWithListener 同步负载均衡及监听器
 	LoadBalancerWithListener(kt *kit.Kit, params *SyncBaseParams, opt *SyncLBOption) (*SyncResult, error)
 
 	// Listener 同步指定负载均衡下的指定云id 负载均衡
 	Listener(kt *kit.Kit, params *SyncBaseParams, opt *SyncListenerOption) (*SyncResult, error)
+	RemoveListenerDeleteFromCloud(kt *kit.Kit, params *ListenerSyncRemovedParams) error
 }
 
 var _ Interface = new(client)

--- a/cmd/hc-service/logics/res-sync/tcloud/load_balancer_target_group.go
+++ b/cmd/hc-service/logics/res-sync/tcloud/load_balancer_target_group.go
@@ -440,7 +440,7 @@ func (cli *client) listListenerWithRule(kt *kit.Kit, listenerCloudID string) (
 	if len(ruleResp.Details) == 0 {
 		logs.Errorf("rule of listener can not be found by id(%s), lbl_id: %s, lbl_cloud_id: %s, rid: %s ",
 			lbl.ID, lbl.CloudID, kt.Rid)
-		return nil, nil, fmt.Errorf("rule of listener  can not be found by id(%s) while target group syncing",
+		return nil, nil, fmt.Errorf("rule of listener can not be found by id(%s) while target group syncing",
 			listenerCloudID)
 	}
 	return cvt.ValToPtr(lbl), cvt.ValToPtr(ruleResp.Details[0]), nil

--- a/cmd/hc-service/logics/res-sync/tcloud/types.go
+++ b/cmd/hc-service/logics/res-sync/tcloud/types.go
@@ -47,3 +47,20 @@ func (opt SyncBaseParams) Validate() error {
 type SyncResult struct {
 	CreatedIds []string
 }
+
+// SyncRemovedParams ...
+type SyncRemovedParams struct {
+	AccountID string `json:"account_id" validate:"required"`
+	Region    string `json:"region" validate:"required"`
+	// 为空表示所有
+	CloudIDs []string `json:"cloud_ids,omitempty" validate:"omitempty"`
+}
+
+// Validate ...
+func (opt SyncRemovedParams) Validate() error {
+
+	if len(opt.CloudIDs) > constant.CloudResourceSyncMaxLimit {
+		return fmt.Errorf("cloudIDs shuold <= %d", constant.CloudResourceSyncMaxLimit)
+	}
+	return validator.Validate.Struct(opt)
+}

--- a/cmd/hc-service/service/load-balancer/tcloud.go
+++ b/cmd/hc-service/service/load-balancer/tcloud.go
@@ -77,6 +77,8 @@ func (svc *clbSvc) initTCloudClbService(cap *capability.Capability) {
 	h.Add("UpdateTCloudListenerHealthCheck", http.MethodPatch,
 		"/vendors/tcloud/listeners/{lbl_id}/health_check", svc.UpdateTCloudListenerHealthCheck)
 	h.Add("DeleteTCloudListener", http.MethodDelete, "/vendors/tcloud/listeners/batch", svc.DeleteTCloudListener)
+	// 仅创建监听器
+	h.Add("CreateTCloudListener", http.MethodPost, "/vendors/tcloud/listeners/create", svc.CreateTCloudListener)
 
 	// 域名、规则
 	h.Add("UpdateTCloudDomainAttr", http.MethodPatch,

--- a/cmd/hc-service/service/load-balancer/tcloud.go
+++ b/cmd/hc-service/service/load-balancer/tcloud.go
@@ -71,7 +71,8 @@ func (svc *clbSvc) initTCloudClbService(cap *capability.Capability) {
 		"/vendors/tcloud/listeners/{lbl_id}/rules/by/domain/batch", svc.TCloudBatchDeleteUrlRuleByDomain)
 
 	// 监听器
-	h.Add("CreateTCloudListener", http.MethodPost, "/vendors/tcloud/listeners/create", svc.CreateTCloudListener)
+	h.Add("CreateTCloudListenerWithTargetGroup", http.MethodPost,
+		"/vendors/tcloud/listeners/create_with_target_group", svc.CreateTCloudListenerWithTargetGroup)
 	h.Add("UpdateTCloudListener", http.MethodPatch, "/vendors/tcloud/listeners/{id}", svc.UpdateTCloudListener)
 	h.Add("UpdateTCloudListenerHealthCheck", http.MethodPatch,
 		"/vendors/tcloud/listeners/{lbl_id}/health_check", svc.UpdateTCloudListenerHealthCheck)
@@ -376,8 +377,8 @@ func (svc *clbSvc) getListenerWithLb(kt *kit.Kit, lblID string) (*corelb.BaseLoa
 	return &lb, &listener, nil
 }
 
-// CreateTCloudListener 创建监听器
-func (svc *clbSvc) CreateTCloudListener(cts *rest.Contexts) (interface{}, error) {
+// CreateTCloudListenerWithTargetGroup 创建监听器和规则附带目标组绑定信息
+func (svc *clbSvc) CreateTCloudListenerWithTargetGroup(cts *rest.Contexts) (interface{}, error) {
 	req := new(protolb.ListenerWithRuleCreateReq)
 	if err := cts.DecodeInto(req); err != nil {
 		return nil, errf.NewFromErr(errf.DecodeRequestFailed, err)

--- a/cmd/hc-service/service/load-balancer/tcloud_listener.go
+++ b/cmd/hc-service/service/load-balancer/tcloud_listener.go
@@ -106,7 +106,7 @@ func (svc *clbSvc) CreateTCloudListener(cts *rest.Contexts) (interface{}, error)
 		SessionExpireTime: req.SessionExpire,
 		Scheduler:         req.Scheduler,
 		SniSwitch:         req.SniSwitch,
-		SessionType:       cvt.ValToPtr(req.SessionType),
+		SessionType:       req.SessionType,
 		Certificate:       req.Certificate,
 	}
 
@@ -176,7 +176,7 @@ func (svc *clbSvc) createListenerDB(kt *kit.Kit, req *protolb.TCloudListenerCrea
 			CloudRuleID:   cloudID,
 			Scheduler:     req.Scheduler,
 			RuleType:      enumor.Layer4RuleType,
-			SessionType:   req.SessionType,
+			SessionType:   cvt.PtrToVal(req.SessionType),
 			SessionExpire: req.SessionExpire,
 			SniSwitch:     req.SniSwitch,
 			Certificate:   req.Certificate,

--- a/cmd/hc-service/service/load-balancer/tcloud_listener.go
+++ b/cmd/hc-service/service/load-balancer/tcloud_listener.go
@@ -128,7 +128,7 @@ func (svc *clbSvc) CreateTCloudListener(cts *rest.Contexts) (interface{}, error)
 		return nil, err
 	}
 
-	return &protolb.ListenerCreateResult{CloudLblID: cloudLblID, LblID: id}, nil
+	return &protolb.ListenerCreateResult{CloudID: cloudLblID, ID: id}, nil
 }
 
 func (svc *clbSvc) createListenerDB(kt *kit.Kit, req *protolb.TCloudListenerCreateReq, lbInfo corelb.BaseLoadBalancer,

--- a/cmd/hc-service/service/load-balancer/tcloud_listener.go
+++ b/cmd/hc-service/service/load-balancer/tcloud_listener.go
@@ -21,10 +21,20 @@
 package loadbalancer
 
 import (
+	"errors"
+
 	loadbalancer "hcm/pkg/adaptor/types/load-balancer"
+	"hcm/pkg/api/core"
+	corelb "hcm/pkg/api/core/cloud/load-balancer"
+	dataproto "hcm/pkg/api/data-service/cloud"
 	protolb "hcm/pkg/api/hc-service/load-balancer"
+	"hcm/pkg/criteria/enumor"
 	"hcm/pkg/criteria/errf"
+	"hcm/pkg/dal/dao/tools"
+	"hcm/pkg/kit"
+	"hcm/pkg/logs"
 	"hcm/pkg/rest"
+	cvt "hcm/pkg/tools/converter"
 )
 
 // QueryListenerTargetsByCloudIDs 直接从云上查询监听器RS列表
@@ -50,4 +60,135 @@ func (svc *clbSvc) QueryListenerTargetsByCloudIDs(cts *rest.Contexts) (any, erro
 		Port:           req.Port,
 	}
 	return tcloud.ListTargets(cts.Kit, listOpt)
+}
+
+// CreateTCloudListener 仅创建监听器自身
+func (svc *clbSvc) CreateTCloudListener(cts *rest.Contexts) (interface{}, error) {
+
+	req := new(protolb.ListenerCreateReq)
+	if err := cts.DecodeInto(req); err != nil {
+		return nil, errf.NewFromErr(errf.DecodeRequestFailed, err)
+	}
+
+	if err := req.Validate(); err != nil {
+		return nil, errf.NewFromErr(errf.InvalidParameter, err)
+	}
+
+	// 根据lbID，查询负载均衡信息
+	lbReq := &core.ListReq{
+		Filter: tools.EqualExpression("id", req.LbID),
+		Page:   core.NewDefaultBasePage(),
+	}
+	lbList, err := svc.dataCli.Global.LoadBalancer.ListLoadBalancer(cts.Kit, lbReq)
+	if err != nil {
+		logs.Errorf("list load balancer by id failed, id: %s, err: %v, rid: %s", req.LbID, err, cts.Kit.Rid)
+		return nil, err
+	}
+	if len(lbList.Details) == 0 {
+		return nil, errf.Newf(errf.RecordNotFound, "load balancer: %s not found", req.LbID)
+	}
+	lbInfo := lbList.Details[0]
+	if req.BkBizID == 0 {
+		// 默认使用负载均衡所在业务
+		req.BkBizID = lbInfo.BkBizID
+	}
+	tcloudAdpt, err := svc.ad.TCloud(cts.Kit, lbInfo.AccountID)
+	if err != nil {
+		return nil, err
+	}
+
+	lblOpt := &loadbalancer.TCloudCreateListenerOption{
+		Region:            lbInfo.Region,
+		LoadBalancerId:    lbInfo.CloudID,
+		ListenerName:      req.Name,
+		Protocol:          req.Protocol,
+		Port:              req.Port,
+		SessionExpireTime: req.SessionExpire,
+		Scheduler:         req.Scheduler,
+		SniSwitch:         req.SniSwitch,
+		SessionType:       cvt.ValToPtr(req.SessionType),
+		Certificate:       req.Certificate,
+	}
+
+	result, err := tcloudAdpt.CreateListener(cts.Kit, lblOpt)
+	if err != nil {
+		logs.Errorf("create tcloud listener api failed, err: %v, lblOpt: %+v, cert: %+v, rid: %s",
+			err, lblOpt, cvt.PtrToVal(lblOpt.Certificate), cts.Kit.Rid)
+		return nil, err
+	}
+	cloudLblID := result.SuccessCloudIDs[0]
+
+	// 插入新的监听器、规则信息到DB
+	id, err := svc.createListenerDB(cts.Kit, req, lbInfo, cloudLblID)
+	if err != nil {
+		logs.Errorf("failed to create tcloud listener db, req: %+v, lbInfo: %+v, cloudID: %s, err: %v, rid: %s",
+			req, lbInfo, cloudLblID, err, cts.Kit.Rid)
+		return nil, err
+	}
+
+	return &protolb.ListenerCreateResult{CloudLblID: cloudLblID, LblID: id}, nil
+}
+
+func (svc *clbSvc) createListenerDB(kt *kit.Kit, req *protolb.ListenerCreateReq, lbInfo corelb.BaseLoadBalancer,
+	cloudID string) (string, error) {
+
+	if req.Protocol.IsLayer7Protocol() {
+		// for layer 7 only create listeners itself
+		lblCreateReq := &dataproto.TCloudListenerBatchCreateReq{
+			Listeners: []dataproto.ListenersCreateReq[corelb.TCloudListenerExtension]{{
+				CloudID:   cloudID,
+				Name:      req.Name,
+				Vendor:    enumor.TCloud,
+				AccountID: lbInfo.AccountID,
+				BkBizID:   lbInfo.BkBizID,
+				LbID:      lbInfo.ID,
+				CloudLbID: lbInfo.CloudID,
+				Protocol:  req.Protocol,
+				Port:      req.Port,
+				Extension: &corelb.TCloudListenerExtension{
+					Certificate: req.Certificate,
+					EndPort:     req.EndPort,
+				},
+			}}}
+		created, err := svc.dataCli.TCloud.LoadBalancer.BatchCreateTCloudListener(kt, lblCreateReq)
+		if err != nil {
+			logs.Errorf("fail to create l7 listener for create listener only, err: %v, req: %+v, rid: %s",
+				err, req, kt.Rid)
+			return "", err
+		}
+		if len(created.IDs) == 0 {
+			return "", errors.New("create tcloud listener db failed, no any listener being created")
+		}
+		return created.IDs[0], nil
+	}
+	// L4 create with rule
+	ruleCreateReq := &dataproto.ListenerWithRuleBatchCreateReq{
+		ListenerWithRules: []dataproto.ListenerWithRuleCreateReq{{
+			CloudID:       cloudID,
+			Name:          req.Name,
+			Vendor:        enumor.TCloud,
+			AccountID:     lbInfo.AccountID,
+			BkBizID:       req.BkBizID,
+			LbID:          lbInfo.ID,
+			CloudLbID:     lbInfo.CloudID,
+			Protocol:      req.Protocol,
+			Port:          req.Port,
+			CloudRuleID:   cloudID,
+			Scheduler:     req.Scheduler,
+			RuleType:      enumor.Layer4RuleType,
+			SessionType:   req.SessionType,
+			SessionExpire: req.SessionExpire,
+			SniSwitch:     req.SniSwitch,
+			Certificate:   req.Certificate,
+		}}}
+	created, err := svc.dataCli.TCloud.LoadBalancer.BatchCreateTCloudListenerWithRule(kt, ruleCreateReq)
+	if err != nil {
+		logs.Errorf("fail to create l4 listener for create listener only, err: %v, req: %+v, rid: %s",
+			err, req, kt.Rid)
+		return "", err
+	}
+	if len(created.IDs) == 0 {
+		return "", errors.New("create tcloud listener db failed, no any listener being created")
+	}
+	return created.IDs[0], nil
 }

--- a/cmd/hc-service/service/load-balancer/tcloud_listener.go
+++ b/cmd/hc-service/service/load-balancer/tcloud_listener.go
@@ -65,7 +65,7 @@ func (svc *clbSvc) QueryListenerTargetsByCloudIDs(cts *rest.Contexts) (any, erro
 // CreateTCloudListener 仅创建监听器自身
 func (svc *clbSvc) CreateTCloudListener(cts *rest.Contexts) (interface{}, error) {
 
-	req := new(protolb.ListenerCreateReq)
+	req := new(protolb.TCloudListenerCreateReq)
 	if err := cts.DecodeInto(req); err != nil {
 		return nil, errf.NewFromErr(errf.DecodeRequestFailed, err)
 	}
@@ -129,7 +129,7 @@ func (svc *clbSvc) CreateTCloudListener(cts *rest.Contexts) (interface{}, error)
 	return &protolb.ListenerCreateResult{CloudLblID: cloudLblID, LblID: id}, nil
 }
 
-func (svc *clbSvc) createListenerDB(kt *kit.Kit, req *protolb.ListenerCreateReq, lbInfo corelb.BaseLoadBalancer,
+func (svc *clbSvc) createListenerDB(kt *kit.Kit, req *protolb.TCloudListenerCreateReq, lbInfo corelb.BaseLoadBalancer,
 	cloudID string) (string, error) {
 
 	if req.Protocol.IsLayer7Protocol() {

--- a/cmd/hc-service/service/load-balancer/tcloud_register_target.go
+++ b/cmd/hc-service/service/load-balancer/tcloud_register_target.go
@@ -85,7 +85,7 @@ func (svc *clbSvc) RegisterTargetToListenerRule(cts *rest.Contexts) (any, error)
 		case enumor.CvmInstType:
 			tmpRs.InstanceId = cvt.ValToPtr(target.CloudInstID)
 		case enumor.EniInstType:
-			// 跨域rs 通过指定为 ip
+			// 跨域rs 通过EniIp参数指定为 ip
 			tmpRs.EniIp = cvt.ValToPtr(target.EniIp)
 		default:
 			return nil, errors.New(string("invalid target type: " + target.TargetType))

--- a/cmd/hc-service/service/sync/tcloud/load_balancer.go
+++ b/cmd/hc-service/service/sync/tcloud/load_balancer.go
@@ -64,7 +64,6 @@ func (hd *lbHandler) Prepare(cts *rest.Contexts) error {
 
 // Next ...
 func (hd *lbHandler) Next(kt *kit.Kit) ([]string, error) {
-
 	listOpt := &typeclb.TCloudListOption{
 		Region: hd.request.Region,
 		// 支持指定资源同步
@@ -111,7 +110,13 @@ func (hd *lbHandler) Sync(kt *kit.Kit, cloudIDs []string) error {
 
 // RemoveDeleteFromCloud ...
 func (hd *lbHandler) RemoveDeleteFromCloud(kt *kit.Kit) error {
-	if err := hd.syncCli.RemoveLoadBalancerDeleteFromCloud(kt, hd.request.AccountID, hd.request.Region); err != nil {
+
+	params := &tcloud.SyncRemovedParams{
+		AccountID: hd.request.AccountID,
+		Region:    hd.request.Region,
+		CloudIDs:  hd.request.CloudIDs,
+	}
+	if err := hd.syncCli.RemoveLoadBalancerDeleteFromCloud(kt, params); err != nil {
 		logs.Errorf("remove load balancer delete from cloud failed, err: %v, accountID: %s, region: %s, rid: %s", err,
 			hd.request.AccountID, hd.request.Region, kt.Rid)
 		return err

--- a/cmd/hc-service/service/sync/tcloud/load_balancer.go
+++ b/cmd/hc-service/service/sync/tcloud/load_balancer.go
@@ -64,8 +64,11 @@ func (hd *lbHandler) Prepare(cts *rest.Contexts) error {
 
 // Next ...
 func (hd *lbHandler) Next(kt *kit.Kit) ([]string, error) {
+
 	listOpt := &typeclb.TCloudListOption{
 		Region: hd.request.Region,
+		// 支持指定资源同步
+		CloudIDs: hd.request.CloudIDs,
 		Page: &typecore.TCloudPage{
 			Offset: hd.offset,
 			Limit:  typecore.TCloudQueryLimit,

--- a/cmd/hc-service/service/sync/tcloud/load_balancer_listener.go
+++ b/cmd/hc-service/service/sync/tcloud/load_balancer_listener.go
@@ -78,7 +78,7 @@ func (hd *lblHandler) Prepare(cts *rest.Contexts) error {
 	}
 	lbResp, err := hd.dataCli.TCloud.LoadBalancer.ListLoadBalancer(cts.Kit, listReq)
 	if err != nil {
-		logs.Errorf("fail to query laod balancer for sync listener, err: %v, listReq:%#v, rid: %s",
+		logs.Errorf("fail to query load balancer for sync listener, err: %v, listReq:%#v, rid: %s",
 			err, listReq, cts.Kit.Rid)
 		return err
 	}
@@ -140,7 +140,8 @@ func (hd *lblHandler) Sync(kt *kit.Kit, cloudIDs []string) error {
 		CachedLoadBalancer: hd.lbInfo,
 	}
 	if _, err := hd.syncCli.Listener(kt, params, opt); err != nil {
-		logs.Errorf("sync tcloud load balancer with rel failed, err: %v, opt: %v, rid: %s", err, params, kt.Rid)
+		logs.Errorf("sync tcloud load balancer with rel failed, err: %v, params: %v, opt: %v, rid: %s",
+			err, params, opt, kt.Rid)
 		return err
 	}
 
@@ -149,6 +150,21 @@ func (hd *lblHandler) Sync(kt *kit.Kit, cloudIDs []string) error {
 
 // RemoveDeleteFromCloud ...
 func (hd *lblHandler) RemoveDeleteFromCloud(kt *kit.Kit) error {
+	params := &tcloud.ListenerSyncRemovedParams{
+		AccountID:          hd.request.AccountID,
+		Region:             hd.request.Region,
+		CloudIDs:           hd.request.CloudIDs,
+		BizID:              hd.lbInfo.BkBizID,
+		LBID:               hd.lbInfo.ID,
+		CloudLBID:          hd.request.LoadBalancerCloudID,
+		CachedLoadBalancer: hd.lbInfo,
+	}
+	err := hd.syncCli.RemoveListenerDeleteFromCloud(kt, params)
+	if err != nil {
+		logs.Errorf("fail to remove deleted tcloud listener, err: %v, params: %v, rid: %s",
+			err, params, kt.Rid)
+		return err
+	}
 	return nil
 }
 

--- a/cmd/hc-service/service/sync/tcloud/load_balancer_listener.go
+++ b/cmd/hc-service/service/sync/tcloud/load_balancer_listener.go
@@ -20,22 +20,29 @@
 package tcloud
 
 import (
+	"fmt"
+
 	ressync "hcm/cmd/hc-service/logics/res-sync"
 	"hcm/cmd/hc-service/logics/res-sync/tcloud"
 	"hcm/cmd/hc-service/service/sync/handler"
 	typecore "hcm/pkg/adaptor/types/core"
 	typeclb "hcm/pkg/adaptor/types/load-balancer"
+	"hcm/pkg/api/core"
+	corelb "hcm/pkg/api/core/cloud/load-balancer"
 	"hcm/pkg/api/hc-service/sync"
+	dataservice "hcm/pkg/client/data-service"
 	"hcm/pkg/criteria/enumor"
 	"hcm/pkg/criteria/errf"
+	"hcm/pkg/dal/dao/tools"
 	"hcm/pkg/kit"
 	"hcm/pkg/logs"
 	"hcm/pkg/rest"
+	cvt "hcm/pkg/tools/converter"
 )
 
 // SyncLoadBalancerListener 同步负载均衡监听器接口
 func (svc *service) SyncLoadBalancerListener(cts *rest.Contexts) (any, error) {
-	return nil, handler.ResourceSync(cts, &lblHandler{cli: svc.syncCli})
+	return nil, handler.ResourceSync(cts, &lblHandler{cli: svc.syncCli, dataCli: svc.dataCli})
 }
 
 // lblHandler lb listener sync handler.
@@ -45,6 +52,8 @@ type lblHandler struct {
 	request *sync.TCloudListenerSyncReq
 	syncCli tcloud.Interface
 	offset  uint64
+	dataCli *dataservice.Client
+	lbInfo  *corelb.TCloudLoadBalancer
 }
 
 var _ handler.Handler = new(lblHandler)
@@ -59,6 +68,25 @@ func (hd *lblHandler) Prepare(cts *rest.Contexts) error {
 	if err := req.Validate(); err != nil {
 		return errf.NewFromErr(errf.InvalidParameter, err)
 	}
+
+	// 查询负载均衡本地数据
+	listReq := &core.ListReq{
+		Filter: tools.ExpressionAnd(
+			tools.RuleEqual("account_id", req.AccountID),
+			tools.RuleEqual("cloud_id", req.LoadBalancerCloudID)),
+		Page: core.NewDefaultBasePage(),
+	}
+	lbResp, err := hd.dataCli.TCloud.LoadBalancer.ListLoadBalancer(cts.Kit, listReq)
+	if err != nil {
+		logs.Errorf("fail to query laod balancer for sync listener, err: %v, listReq:%#v, rid: %s",
+			err, listReq, cts.Kit.Rid)
+		return err
+	}
+	// 本地没有的数据不支持同步
+	if len(lbResp.Details) == 0 {
+		return fmt.Errorf("load balancer(%s) cannot be found in database", hd.request.LoadBalancerCloudID)
+	}
+	hd.lbInfo = cvt.ValToPtr(lbResp.Details[0])
 
 	syncCli, err := hd.cli.TCloud(cts.Kit, req.AccountID)
 	if err != nil {
@@ -76,9 +104,7 @@ func (hd *lblHandler) Next(kt *kit.Kit) ([]string, error) {
 	listOpt := &typeclb.TCloudListListenersOption{
 		Region:         hd.request.Region,
 		LoadBalancerId: hd.request.LoadBalancerCloudID,
-		CloudIDs:       hd.request.ListenerCloudIds,
-		Protocol:       "",
-		Port:           0,
+		CloudIDs:       hd.request.CloudIDs,
 	}
 
 	lbResult, err := hd.syncCli.CloudCli().ListListener(kt, listOpt)
@@ -108,9 +134,10 @@ func (hd *lblHandler) Sync(kt *kit.Kit, cloudIDs []string) error {
 		CloudIDs:  cloudIDs,
 	}
 	opt := &tcloud.SyncListenerOption{
-		BizID:     0,
-		LBID:      "",
-		CloudLBID: hd.request.LoadBalancerCloudID,
+		BizID:              hd.lbInfo.BkBizID,
+		LBID:               hd.lbInfo.ID,
+		CloudLBID:          hd.request.LoadBalancerCloudID,
+		CachedLoadBalancer: hd.lbInfo,
 	}
 	if _, err := hd.syncCli.Listener(kt, params, opt); err != nil {
 		logs.Errorf("sync tcloud load balancer with rel failed, err: %v, opt: %v, rid: %s", err, params, kt.Rid)
@@ -122,12 +149,6 @@ func (hd *lblHandler) Sync(kt *kit.Kit, cloudIDs []string) error {
 
 // RemoveDeleteFromCloud ...
 func (hd *lblHandler) RemoveDeleteFromCloud(kt *kit.Kit) error {
-	if err := hd.syncCli.RemoveLoadBalancerDeleteFromCloud(kt, hd.request.AccountID, hd.request.Region); err != nil {
-		logs.Errorf("remove load balancer delete from cloud failed, err: %v, accountID: %s, region: %s, rid: %s", err,
-			hd.request.AccountID, hd.request.Region, kt.Rid)
-		return err
-	}
-
 	return nil
 }
 

--- a/cmd/hc-service/service/sync/tcloud/service.go
+++ b/cmd/hc-service/service/sync/tcloud/service.go
@@ -54,6 +54,7 @@ func InitService(cap *capability.Capability) {
 	h.Add("SyncArgsTpl", "POST", "/argument_templates/sync", v.SyncArgsTpl)
 	h.Add("SyncCert", "POST", "/certs/sync", v.SyncCert)
 	h.Add("SyncLoadBalancer", "POST", "/load_balancers/sync", v.SyncLoadBalancer)
+	h.Add("SyncLoadBalancerListener", "POST", "/listeners/sync", v.SyncLoadBalancerListener)
 
 	h.Load(cap.WebService)
 }

--- a/cmd/task-server/logics/action/init.go
+++ b/cmd/task-server/logics/action/init.go
@@ -81,4 +81,8 @@ func register() {
 
 	action.RegisterAction(actionlb.DeleteURLRuleAction{})
 	action.RegisterAction(actionlb.DeleteListenerAction{})
+
+	action.RegisterAction(actionlb.BatchTaskBindTargetAction{})
+	action.RegisterAction(actionlb.BatchTaskTCloudCreateL7RuleAction{})
+	action.RegisterAction(actionlb.BatchTaskTCloudCreateListenerAction{})
 }

--- a/cmd/task-server/logics/action/load-balancer/batch_task_common.go
+++ b/cmd/task-server/logics/action/load-balancer/batch_task_common.go
@@ -1,0 +1,205 @@
+/*
+ * TencentBlueKing is pleased to support the open source community by making
+ * 蓝鲸智云 - 混合云管理平台 (BlueKing - Hybrid Cloud Management System) available.
+ * Copyright (C) 2024 THL A29 Limited,
+ * a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * We undertake not to change the open source license (MIT license) applicable
+ *
+ * to the current version of the project delivered to anyone in the future.
+ */
+
+package actionlb
+
+import (
+	actcli "hcm/cmd/task-server/logics/action/cli"
+	"hcm/pkg/api/core"
+	corelb "hcm/pkg/api/core/cloud/load-balancer"
+	coretask "hcm/pkg/api/core/task"
+	datatask "hcm/pkg/api/data-service/task"
+	"hcm/pkg/criteria/enumor"
+	"hcm/pkg/criteria/errf"
+	"hcm/pkg/dal/dao/tools"
+	"hcm/pkg/kit"
+	"hcm/pkg/logs"
+	"hcm/pkg/tools/assert"
+)
+
+func listTaskDetail(kt *kit.Kit, ids []string) ([]coretask.Detail, error) {
+	// 查询任务状态
+	detailListReq := &core.ListReq{
+		Filter: tools.ContainersExpression("id", ids),
+		Page:   core.NewDefaultBasePage(),
+	}
+	detailResp, err := actcli.GetDataService().Global.TaskDetail.List(kt, detailListReq)
+	if err != nil {
+		logs.Errorf("fail to query task detail, err: %v, rid: %s", err, kt.Rid)
+		return nil, err
+	}
+	if len(detailResp.Details) != len(ids) {
+
+		return nil, errf.New(errf.InvalidParameter, "some of task management detail ids not found, want: %d, got: %s")
+	}
+	return detailResp.Details, nil
+}
+
+func batchUpdateTaskDetailState(kt *kit.Kit, ids []string, state enumor.TaskDetailState) error {
+
+	detailUpdates := make([]datatask.UpdateTaskDetailField, 0, len(ids))
+	for i := range ids {
+		field := datatask.UpdateTaskDetailField{ID: ids[i], State: state}
+		detailUpdates = append(detailUpdates, field)
+	}
+	updateTaskReq := &datatask.UpdateDetailReq{Items: detailUpdates}
+	err := actcli.GetDataService().Global.TaskDetail.Update(kt, updateTaskReq)
+	if err != nil {
+		logs.Errorf("fail to update task detail state to %s, err: %v, ids: %s， rid: %s",
+			state, err, ids, kt.Rid)
+		return err
+	}
+	return nil
+}
+
+func getListenerWithLb(kt *kit.Kit, lblID string) (*corelb.BaseLoadBalancer,
+	*corelb.BaseListener, error) {
+
+	// 查询监听器数据
+	listenerReq := &core.ListReq{
+		Filter: tools.EqualExpression("id", lblID),
+		Page:   core.NewDefaultBasePage(),
+		Fields: nil,
+	}
+	lblResp, err := actcli.GetDataService().Global.LoadBalancer.ListListener(kt, listenerReq)
+	if err != nil {
+		logs.Errorf("fail to list tcloud listener, err: %v, id: %s, rid: %s", err, lblID, kt.Rid)
+		return nil, nil, err
+	}
+	if len(lblResp.Details) < 1 {
+		return nil, nil, errf.Newf(errf.InvalidParameter, "lbl not found")
+	}
+	listener := lblResp.Details[0]
+
+	// 查询负载均衡
+	lbReq := &core.ListReq{
+		Filter: tools.EqualExpression("id", listener.LbID),
+		Page:   core.NewDefaultBasePage(),
+		Fields: nil,
+	}
+	lbResp, err := actcli.GetDataService().Global.LoadBalancer.ListLoadBalancer(kt, lbReq)
+	if err != nil {
+		logs.Errorf("fail to list tcloud load balancer, err: %v, id: %s, rid: %s", err, listener.LbID, kt.Rid)
+		return nil, nil, err
+	}
+	if len(lbResp.Details) < 1 {
+		return nil, nil, errf.Newf(errf.RecordNotFound, "lb not found")
+	}
+	lb := lbResp.Details[0]
+	return &lb, &listener, nil
+}
+
+// 七层规则不支持设置检查端口
+func isHealthCheckChange(req *corelb.TCloudHealthCheckInfo, db *corelb.TCloudHealthCheckInfo, isL7 bool) bool {
+	if req == nil {
+		// 请求为空，默认参数
+		return false
+	}
+	if db == nil {
+		// 数据库为空，认为是默认参数
+		return false
+	}
+	if !assert.IsPtrInt64Equal(req.HealthSwitch, db.HealthSwitch) {
+		return true
+	}
+	if !assert.IsPtrInt64Equal(req.TimeOut, db.TimeOut) {
+		return true
+	}
+	if !assert.IsPtrInt64Equal(req.IntervalTime, db.IntervalTime) {
+		return true
+	}
+	if !assert.IsPtrInt64Equal(req.HealthNum, db.HealthNum) {
+		return true
+	}
+	if !assert.IsPtrInt64Equal(req.UnHealthNum, db.UnHealthNum) {
+		return true
+	}
+	if !assert.IsPtrInt64Equal(req.HttpCode, db.HttpCode) {
+		return true
+	}
+	if !assert.IsPtrStringEqual(req.HttpCheckPath, db.HttpCheckPath) {
+		return true
+	}
+	if !assert.IsPtrStringEqual(req.HttpCheckDomain, db.HttpCheckDomain) {
+		return true
+	}
+	if !assert.IsPtrStringEqual(req.HttpCheckMethod, db.HttpCheckMethod) {
+		return true
+	}
+	// 七层规则不支持设置检查端口, 这里不比较该数据
+	if isL7 && !assert.IsPtrInt64Equal(req.CheckPort, db.CheckPort) {
+		return true
+	}
+	if !assert.IsPtrStringEqual(req.ContextType, db.ContextType) {
+		return true
+	}
+	if !assert.IsPtrStringEqual(req.SendContext, db.SendContext) {
+		return true
+	}
+	if !assert.IsPtrStringEqual(req.RecvContext, db.RecvContext) {
+		return true
+	}
+	if !assert.IsPtrStringEqual(req.CheckType, db.CheckType) {
+		return true
+	}
+	if !assert.IsPtrStringEqual(req.HttpVersion, db.HttpVersion) {
+		return true
+	}
+
+	if !assert.IsPtrInt64Equal(req.SourceIpType, db.SourceIpType) {
+		return true
+	}
+	if !assert.IsPtrStringEqual(req.ExtendedCode, db.ExtendedCode) {
+		return true
+	}
+
+	return false
+}
+
+func isListenerCertChange(want *corelb.TCloudCertificateInfo, db *corelb.TCloudCertificateInfo) bool {
+	if want == nil {
+		// 请求为空，默认参数
+		return false
+	}
+	if db == nil {
+		// 数据库为空，认为是默认参数
+		return false
+	}
+
+	if !assert.IsPtrStringEqual(want.SSLMode, db.SSLMode) {
+		return true
+	}
+
+	if !assert.IsPtrStringEqual(want.CaCloudID, db.CaCloudID) {
+		return true
+	}
+
+	// 都有，但是数量不相等
+	if len(db.CertCloudIDs) != len(want.CertCloudIDs) {
+		// 数量不相等
+		return true
+	}
+	// 要求证书按顺序相等。
+	for i := range want.CertCloudIDs {
+		if db.CertCloudIDs[i] != want.CertCloudIDs[i] {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/task-server/logics/action/load-balancer/batch_task_common.go
+++ b/cmd/task-server/logics/action/load-balancer/batch_task_common.go
@@ -51,11 +51,14 @@ func listTaskDetail(kt *kit.Kit, ids []string) ([]coretask.Detail, error) {
 	return detailResp.Details, nil
 }
 
-func batchUpdateTaskDetailState(kt *kit.Kit, ids []string, state enumor.TaskDetailState) error {
+func batchUpdateTaskDetailState(kt *kit.Kit, ids []string, state enumor.TaskDetailState, reason error) error {
 
 	detailUpdates := make([]datatask.UpdateTaskDetailField, 0, len(ids))
 	for i := range ids {
 		field := datatask.UpdateTaskDetailField{ID: ids[i], State: state}
+		if reason != nil {
+			field.Reason = reason.Error()
+		}
 		detailUpdates = append(detailUpdates, field)
 	}
 	updateTaskReq := &datatask.UpdateDetailReq{Items: detailUpdates}

--- a/cmd/task-server/logics/action/load-balancer/batch_task_tcloud_bind_targets.go
+++ b/cmd/task-server/logics/action/load-balancer/batch_task_tcloud_bind_targets.go
@@ -91,7 +91,7 @@ func (act BatchTaskBindTargetAction) Run(kt run.ExecuteKit, params any) (result 
 		}
 	}
 	// 更新任务状态为 running
-	if err := batchUpdateTaskDetailState(kt.Kit(), opt.ManagementDetailIDs, enumor.TaskDetailRunning, nil); err != nil {
+	if err := batchUpdateTaskDetailState(kt.Kit(), opt.ManagementDetailIDs, enumor.TaskDetailRunning); err != nil {
 		return fmt.Sprintf("fail to update detail to running"), err
 	}
 
@@ -102,7 +102,7 @@ func (act BatchTaskBindTargetAction) Run(kt run.ExecuteKit, params any) (result 
 			// 更新为失败
 			targetState = enumor.TaskDetailFailed
 		}
-		err := batchUpdateTaskDetailState(kt.Kit(), opt.ManagementDetailIDs, targetState, taskErr)
+		err := batchUpdateTaskDetailResultState(kt.Kit(), opt.ManagementDetailIDs, targetState, nil, taskErr)
 		if err != nil {
 			logs.Errorf("fail to set detail to %s after cloud operation finished, err: %v, rid: %s",
 				targetState, err, kt.Kit().Rid)

--- a/cmd/task-server/logics/action/load-balancer/batch_task_tcloud_bind_targets.go
+++ b/cmd/task-server/logics/action/load-balancer/batch_task_tcloud_bind_targets.go
@@ -91,7 +91,7 @@ func (act BatchTaskBindTargetAction) Run(kt run.ExecuteKit, params any) (result 
 		}
 	}
 	// 更新任务状态为 running
-	if err := batchUpdateTaskDetailState(kt.Kit(), opt.ManagementDetailIDs, enumor.TaskDetailRunning); err != nil {
+	if err := batchUpdateTaskDetailState(kt.Kit(), opt.ManagementDetailIDs, enumor.TaskDetailRunning, nil); err != nil {
 		return fmt.Sprintf("fail to update detail to running"), err
 	}
 
@@ -102,7 +102,7 @@ func (act BatchTaskBindTargetAction) Run(kt run.ExecuteKit, params any) (result 
 			// 更新为失败
 			targetState = enumor.TaskDetailFailed
 		}
-		err := batchUpdateTaskDetailState(kt.Kit(), opt.ManagementDetailIDs, targetState)
+		err := batchUpdateTaskDetailState(kt.Kit(), opt.ManagementDetailIDs, targetState, taskErr)
 		if err != nil {
 			logs.Errorf("fail to set detail to %s after cloud operation finished, err: %v, rid: %s",
 				targetState, err, kt.Kit().Rid)

--- a/cmd/task-server/logics/action/load-balancer/batch_task_tcloud_bind_targets.go
+++ b/cmd/task-server/logics/action/load-balancer/batch_task_tcloud_bind_targets.go
@@ -1,0 +1,127 @@
+/*
+ * TencentBlueKing is pleased to support the open source community by making
+ * 蓝鲸智云 - 混合云管理平台 (BlueKing - Hybrid Cloud Management System) available.
+ * Copyright (C) 2024 THL A29 Limited,
+ * a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * We undertake not to change the open source license (MIT license) applicable
+ *
+ * to the current version of the project delivered to anyone in the future.
+ */
+
+package actionlb
+
+import (
+	"fmt"
+
+	actcli "hcm/cmd/task-server/logics/action/cli"
+	hclb "hcm/pkg/api/hc-service/load-balancer"
+	"hcm/pkg/async/action"
+	"hcm/pkg/async/action/run"
+	"hcm/pkg/criteria/enumor"
+	"hcm/pkg/criteria/errf"
+	"hcm/pkg/criteria/validator"
+	"hcm/pkg/logs"
+)
+
+// --------------------------[批量操作-绑定RS]-----------------------------
+
+var _ action.Action = new(BatchTaskBindTargetAction)
+var _ action.ParameterAction = new(BatchTaskBindTargetAction)
+
+// BatchTaskBindTargetAction 批量操作-绑定RS 将目标组中的RS应用到监听器或者规则
+type BatchTaskBindTargetAction struct{}
+
+// BatchTaskBindTargetOption ...
+type BatchTaskBindTargetOption struct {
+	LoadBalancerID string `json:"lb_id" validate:"required"`
+	// ManagementDetailIDs 对应的详情行id列表，需要和批量绑定的Targets参数长度对应
+	ManagementDetailIDs                []string `json:"management_detail_ids" validate:"required,max=500"`
+	*hclb.BatchRegisterTCloudTargetReq `json:",inline"`
+}
+
+// Validate validate option.
+func (opt BatchTaskBindTargetOption) Validate() error {
+	if opt.BatchRegisterTCloudTargetReq == nil {
+		return errf.New(errf.InvalidParameter, "batch_register_tcloud_target_req is required")
+	}
+	if len(opt.ManagementDetailIDs) != len(opt.BatchRegisterTCloudTargetReq.Targets) {
+		return errf.Newf(errf.InvalidParameter, "management_detail_ids and targets length not match, %d != %d",
+			len(opt.ManagementDetailIDs), len(opt.BatchRegisterTCloudTargetReq.Targets))
+	}
+	return validator.Validate.Struct(opt)
+}
+
+// ParameterNew return request params.
+func (act BatchTaskBindTargetAction) ParameterNew() (params any) {
+	return new(BatchTaskBindTargetOption)
+}
+
+// Name return action name
+func (act BatchTaskBindTargetAction) Name() enumor.ActionName {
+	return enumor.ActionBatchTaskTCloudBindTarget
+}
+
+// Run 将目标组中的RS绑定到监听器/规则中
+func (act BatchTaskBindTargetAction) Run(kt run.ExecuteKit, params any) (result any, taskErr error) {
+	opt, ok := params.(*BatchTaskBindTargetOption)
+	if !ok {
+		return nil, errf.New(errf.InvalidParameter, "params type mismatch")
+	}
+	detailList, err := listTaskDetail(kt.Kit(), opt.ManagementDetailIDs)
+	if err != nil {
+		return fmt.Sprintf("task detail query failed"), err
+	}
+	for _, detail := range detailList {
+		if detail.State == enumor.TaskDetailCancel {
+			// 任务被取消，跳过该批次
+			return fmt.Sprintf("task detail %s canceled", detail.ID), nil
+		}
+		if detail.State != enumor.TaskDetailInit {
+			return nil, errf.Newf(errf.InvalidParameter, "task management detail(%s) status(%s) is not init",
+				detail.ID, detail.State)
+		}
+	}
+	// 更新任务状态为 running
+	if err := batchUpdateTaskDetailState(kt.Kit(), opt.ManagementDetailIDs, enumor.TaskDetailRunning); err != nil {
+		return fmt.Sprintf("fail to update detail to running"), err
+	}
+
+	defer func() {
+		// 结束后写回状态
+		targetState := enumor.TaskDetailSuccess
+		if taskErr != nil {
+			// 更新为失败
+			targetState = enumor.TaskDetailFailed
+		}
+		err := batchUpdateTaskDetailState(kt.Kit(), opt.ManagementDetailIDs, targetState)
+		if err != nil {
+			logs.Errorf("fail to set detail to %s after cloud operation finished, err: %v, rid: %s",
+				targetState, err, kt.Kit().Rid)
+		}
+	}()
+
+	err = actcli.GetHCService().TCloud.Clb.BatchRegisterTargetToListenerRule(kt.Kit(), opt.LoadBalancerID,
+		opt.BatchRegisterTCloudTargetReq)
+	if err != nil {
+		logs.Errorf("fail to register target to listener rule, err: %v, rid: %s", err, kt.Kit().Rid)
+		return nil, err
+	}
+
+	return nil, nil
+}
+
+// Rollback 添加rs支持重入，无需回滚
+func (act BatchTaskBindTargetAction) Rollback(kt run.ExecuteKit, params any) error {
+	logs.Infof(" ----------- BatchTaskBindTargetAction Rollback -----------, params: %+v, rid: %s",
+		params, kt.Kit().Rid)
+	return nil
+}

--- a/cmd/task-server/logics/action/load-balancer/batch_task_tcloud_create_l7rule.go
+++ b/cmd/task-server/logics/action/load-balancer/batch_task_tcloud_create_l7rule.go
@@ -117,7 +117,7 @@ func (act BatchTaskTCloudCreateL7RuleAction) Run(kt run.ExecuteKit, params any) 
 
 	// 进入创建
 	// 更新任务状态为 running
-	if err := batchUpdateTaskDetailState(kt.Kit(), opt.ManagementDetailIDs, enumor.TaskDetailRunning); err != nil {
+	if err := batchUpdateTaskDetailState(kt.Kit(), opt.ManagementDetailIDs, enumor.TaskDetailRunning, nil); err != nil {
 		return fmt.Sprintf("fail to update detail to running"), err
 	}
 
@@ -128,7 +128,7 @@ func (act BatchTaskTCloudCreateL7RuleAction) Run(kt run.ExecuteKit, params any) 
 			// 更新为失败
 			targetState = enumor.TaskDetailFailed
 		}
-		err := batchUpdateTaskDetailState(kt.Kit(), opt.ManagementDetailIDs, targetState)
+		err := batchUpdateTaskDetailState(kt.Kit(), opt.ManagementDetailIDs, targetState, taskErr)
 		if err != nil {
 			logs.Errorf("fail to set detail to %s after cloud operation finished, err: %v, rid: %s",
 				targetState, err, kt.Kit().Rid)

--- a/cmd/task-server/logics/action/load-balancer/batch_task_tcloud_create_l7rule.go
+++ b/cmd/task-server/logics/action/load-balancer/batch_task_tcloud_create_l7rule.go
@@ -157,7 +157,6 @@ func (act BatchTaskTCloudCreateL7RuleAction) skipExistsRule(kt *kit.Kit, opt *Ba
 		// 查询是否已经存在对应规则
 		listRuleReq := &core.ListReq{
 			Filter: tools.ExpressionAnd(
-				tools.RuleEqual("vendor", enumor.TCloud),
 				tools.RuleEqual("lb_id", opt.LoadBalancerID),
 				tools.RuleEqual("lbl_id", opt.ListenerID),
 				tools.RuleEqual("domain", reqRule.Domains[0]),

--- a/cmd/task-server/logics/action/load-balancer/batch_task_tcloud_create_l7rule.go
+++ b/cmd/task-server/logics/action/load-balancer/batch_task_tcloud_create_l7rule.go
@@ -1,0 +1,221 @@
+/*
+ * TencentBlueKing is pleased to support the open source community by making
+ * 蓝鲸智云 - 混合云管理平台 (BlueKing - Hybrid Cloud Management System) available.
+ * Copyright (C) 2024 THL A29 Limited,
+ * a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * We undertake not to change the open source license (MIT license) applicable
+ *
+ * to the current version of the project delivered to anyone in the future.
+ */
+
+package actionlb
+
+import (
+	"fmt"
+
+	actcli "hcm/cmd/task-server/logics/action/cli"
+	"hcm/pkg/api/core"
+	corelb "hcm/pkg/api/core/cloud/load-balancer"
+	hclb "hcm/pkg/api/hc-service/load-balancer"
+	"hcm/pkg/async/action"
+	"hcm/pkg/async/action/run"
+	"hcm/pkg/criteria/enumor"
+	"hcm/pkg/criteria/errf"
+	"hcm/pkg/criteria/validator"
+	"hcm/pkg/dal/dao/tools"
+	"hcm/pkg/kit"
+	"hcm/pkg/logs"
+	cvt "hcm/pkg/tools/converter"
+)
+
+// --------------------------[TCloud创建7层规则]-----------------------------
+
+var _ action.Action = new(BatchTaskTCloudCreateL7RuleAction)
+var _ action.ParameterAction = new(BatchTaskTCloudCreateL7RuleAction)
+
+// BatchTaskTCloudCreateL7RuleAction TCloud创建7层规则
+type BatchTaskTCloudCreateL7RuleAction struct{}
+
+// BatchTaskTCloudCreateL7RuleOption ...
+type BatchTaskTCloudCreateL7RuleOption struct {
+	LoadBalancerID                 string   `json:"lb_id" validate:"required"`
+	ListenerID                     string   `json:"listener_id" validate:"required"`
+	ManagementDetailIDs            []string `json:"management_detail_ids" validate:"required,min=1,max=20"`
+	*hclb.TCloudRuleBatchCreateReq `json:"inline" validate:"required,dive,required"`
+}
+
+// Validate validate option.
+func (opt BatchTaskTCloudCreateL7RuleOption) Validate() error {
+	if len(opt.ManagementDetailIDs) != len(opt.TCloudRuleBatchCreateReq.Rules) {
+		return errf.Newf(errf.InvalidParameter, "management_detail_ids and rules length not match: %d! = %d",
+			len(opt.ManagementDetailIDs), len(opt.TCloudRuleBatchCreateReq.Rules))
+	}
+	return validator.Validate.Struct(opt)
+}
+
+// ParameterNew return request params.
+func (act BatchTaskTCloudCreateL7RuleAction) ParameterNew() (params any) {
+	return new(BatchTaskTCloudCreateL7RuleOption)
+}
+
+// Name return action name
+func (act BatchTaskTCloudCreateL7RuleAction) Name() enumor.ActionName {
+	return enumor.ActionBatchTaskTCloudCreateL7Rule
+}
+
+// Run 创建监听器
+func (act BatchTaskTCloudCreateL7RuleAction) Run(kt run.ExecuteKit, params any) (result any, taskErr error) {
+	opt, ok := params.(*BatchTaskTCloudCreateL7RuleOption)
+	if !ok {
+		return nil, errf.New(errf.InvalidParameter, "params type mismatch")
+	}
+
+	// 查询 负载均衡、监听器是否正确
+	lb, _, err := getListenerWithLb(kt.Kit(), opt.ListenerID)
+	if err != nil {
+		logs.Errorf("fail to get listener with lb, err: %v, rid: %s", err, kt.Kit().Rid)
+		return nil, err
+	}
+	if lb.ID != opt.LoadBalancerID {
+		return nil, errf.Newf(errf.InvalidParameter, "loadbalancer id mismatch, want: %s, got: %s",
+			opt.LoadBalancerID, lb.ID)
+	}
+
+	detailList, err := listTaskDetail(kt.Kit(), opt.ManagementDetailIDs)
+	if err != nil {
+		return fmt.Sprintf("task detail query failed"), err
+	}
+	for _, detail := range detailList {
+		if detail.State == enumor.TaskDetailCancel {
+			// 任务被取消，跳过该批次
+			return fmt.Sprintf("task detail %s canceled", detail.ID), nil
+		}
+		if detail.State != enumor.TaskDetailInit {
+			return nil, errf.Newf(errf.InvalidParameter, "task management detail(%s) status(%s) is not init",
+				detail.ID, detail.State)
+		}
+	}
+
+	nonExistsReq, err := act.skipExistsRule(kt.Kit(), opt)
+	if err != nil {
+		return nil, err
+	}
+	if len(nonExistsReq.Rules) == 0 {
+		// 已存在跳过
+		logs.Infof("all rule exists, skip, rid: %s", kt.Kit().Rid)
+		return "all rule exists", nil
+	}
+
+	// 进入创建
+	// 更新任务状态为 running
+	if err := batchUpdateTaskDetailState(kt.Kit(), opt.ManagementDetailIDs, enumor.TaskDetailRunning); err != nil {
+		return fmt.Sprintf("fail to update detail to running"), err
+	}
+
+	defer func() {
+		// 结束后写回状态
+		targetState := enumor.TaskDetailSuccess
+		if taskErr != nil {
+			// 更新为失败
+			targetState = enumor.TaskDetailFailed
+		}
+		err := batchUpdateTaskDetailState(kt.Kit(), opt.ManagementDetailIDs, targetState)
+		if err != nil {
+			logs.Errorf("fail to set detail to %s after cloud operation finished, err: %v, rid: %s",
+				targetState, err, kt.Kit().Rid)
+		}
+	}()
+
+	lblResp, err := actcli.GetHCService().TCloud.Clb.BatchCreateUrlRule(kt.Kit(), lb.ID, nonExistsReq)
+	if err != nil {
+		logs.Errorf("fail to call hc to create tcloud l7 rules, err: %v, rid: %s", err, kt.Kit().Rid)
+		return nil, err
+	}
+	// all success
+	return lblResp, err
+}
+
+// 查询规则是否存在，返回不存在的规则入参。如果存在且参数一样跳过，如果存在但不符合入参则报错。
+func (act BatchTaskTCloudCreateL7RuleAction) skipExistsRule(kt *kit.Kit, opt *BatchTaskTCloudCreateL7RuleOption) (
+	nonExistReq *hclb.TCloudRuleBatchCreateReq, err error) {
+
+	nonExistReq = &hclb.TCloudRuleBatchCreateReq{
+		Rules: make([]hclb.TCloudRuleCreate, 0, len(opt.Rules)),
+	}
+	for i := range opt.Rules {
+		reqRule := opt.Rules[i]
+
+		// 查询是否已经存在对应规则
+		listRuleReq := &core.ListReq{
+			Filter: tools.ExpressionAnd(
+				tools.RuleEqual("vendor", enumor.TCloud),
+				tools.RuleEqual("lb_id", opt.LoadBalancerID),
+				tools.RuleEqual("lbl_id", opt.ListenerID),
+				tools.RuleEqual("domain", reqRule.Domains[0]),
+				tools.RuleEqual("url", reqRule.Url),
+			),
+			Page: core.NewDefaultBasePage(),
+		}
+		ruleResp, err := actcli.GetDataService().TCloud.LoadBalancer.ListUrlRule(kt, listRuleReq)
+		if err != nil {
+			return nil, fmt.Errorf("fail to query listener, err: %v", err)
+		}
+
+		if len(ruleResp.Details) == 0 {
+			// 不存在直接创建
+			nonExistReq.Rules = append(nonExistReq.Rules, reqRule)
+			continue
+		}
+		dbRule := ruleResp.Details[0]
+		if err := act.checkRuleMatch(reqRule, dbRule); err != nil {
+			return nil, fmt.Errorf("check rule exists failed, err: %v, idx: %d", err, i)
+		}
+		// 存在但是不冲突也加入创建
+		nonExistReq.Rules = append(nonExistReq.Rules, reqRule)
+	}
+
+	return nonExistReq, nil
+}
+
+func (act BatchTaskTCloudCreateL7RuleAction) checkRuleMatch(req hclb.TCloudRuleCreate, db corelb.TCloudLbUrlRule) (
+	err error) {
+
+	if req.SessionExpireTime != nil && db.SessionExpire != cvt.PtrToVal(req.SessionExpireTime) {
+		return fmt.Errorf("url rule(%s) session expire time mismatch, want: %d, got: %d",
+			req.Url, cvt.PtrToVal(req.SessionExpireTime), db.SessionExpire)
+	}
+	if req.Scheduler != nil && db.Scheduler != cvt.PtrToVal(req.Scheduler) {
+		return fmt.Errorf("url rule(%s) scheduler mismatch, want: %s, got: %s",
+			req.Url, cvt.PtrToVal(req.Scheduler), db.Scheduler)
+	}
+	if len(req.Domains) > 0 && req.Domains[0] != db.Domain {
+		return fmt.Errorf("url rule(%s) domain mismatch, want: %+v, got: %+v",
+			req.Url, req.Domains, db.Domain)
+	}
+	if req.HealthCheck != nil && isHealthCheckChange(req.HealthCheck, db.HealthCheck, true) {
+		return fmt.Errorf("url rule(%s) health check mismatch, want: %+v, got: %+v",
+			req.Url, cvt.PtrToVal(req.HealthCheck), db.HealthCheck)
+	}
+	if req.Certificates != nil && isListenerCertChange(req.Certificates, db.Certificate) {
+		return fmt.Errorf("url rule(%s) certificates mismatch, want: %+v, got: %+v",
+			req.Url, cvt.PtrToVal(req.Certificates), db.Certificate)
+	}
+
+	return nil
+}
+
+// Rollback 支持重入，无需回滚
+func (act BatchTaskTCloudCreateL7RuleAction) Rollback(kt run.ExecuteKit, params any) error {
+	logs.Infof(" ----------- BatchTaskTCloudCreateL7RuleAction Rollback -----------, params: %+v, rid: %s",
+		params, kt.Kit().Rid)
+	return nil
+}

--- a/cmd/task-server/logics/action/load-balancer/batch_task_tcloud_create_l7rule.go
+++ b/cmd/task-server/logics/action/load-balancer/batch_task_tcloud_create_l7rule.go
@@ -82,7 +82,7 @@ func (act BatchTaskTCloudCreateL7RuleAction) Run(kt run.ExecuteKit, params any) 
 	// 查询 负载均衡、监听器是否正确
 	lb, _, err := getListenerWithLb(kt.Kit(), opt.ListenerID)
 	if err != nil {
-		logs.Errorf("fail to get listener with lb, err: %v, rid: %s", err, kt.Kit().Rid)
+		logs.Errorf("fail to get listener with lb, err: %v, listner: %s, rid: %s", err, opt.ListenerID, kt.Kit().Rid)
 		return nil, err
 	}
 	if lb.ID != opt.LoadBalancerID {
@@ -141,7 +141,7 @@ func (act BatchTaskTCloudCreateL7RuleAction) Run(kt run.ExecuteKit, params any) 
 		return nil, err
 	}
 	// all success
-	return lblResp, err
+	return lblResp, nil
 }
 
 // 查询规则是否存在，返回不存在的规则入参。如果存在且参数一样跳过，如果存在但不符合入参则报错。

--- a/cmd/task-server/logics/action/load-balancer/batch_task_tcloud_create_listener.go
+++ b/cmd/task-server/logics/action/load-balancer/batch_task_tcloud_create_listener.go
@@ -85,7 +85,7 @@ func (act BatchTaskTCloudCreateListenerAction) Run(kt run.ExecuteKit, params any
 			// 更新为失败
 			targetState = enumor.TaskDetailFailed
 		}
-		err := batchUpdateTaskDetailState(kt.Kit(), []string{detailID}, targetState)
+		err := batchUpdateTaskDetailState(kt.Kit(), []string{detailID}, targetState, createErr)
 		if err != nil {
 			logs.Errorf("fail to set detail to %s after cloud operation finished, err: %v, rid: %s",
 				targetState, err, kt.Kit().Rid)
@@ -127,7 +127,7 @@ func (act BatchTaskTCloudCreateListenerAction) createSingleListener(kt *kit.Kit,
 	}
 
 	// 更新任务状态为 running
-	if err := batchUpdateTaskDetailState(kt, []string{detailId}, enumor.TaskDetailRunning); err != nil {
+	if err := batchUpdateTaskDetailState(kt, []string{detailId}, enumor.TaskDetailRunning, nil); err != nil {
 		return nil, fmt.Errorf("fail to update detail to running, err: %v", err)
 	}
 	lblResp, err := actcli.GetHCService().TCloud.Clb.CreateListener(kt, req)

--- a/cmd/task-server/logics/action/load-balancer/batch_task_tcloud_create_listener.go
+++ b/cmd/task-server/logics/action/load-balancer/batch_task_tcloud_create_listener.go
@@ -1,0 +1,211 @@
+/*
+ * TencentBlueKing is pleased to support the open source community by making
+ * 蓝鲸智云 - 混合云管理平台 (BlueKing - Hybrid Cloud Management System) available.
+ * Copyright (C) 2024 THL A29 Limited,
+ * a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * We undertake not to change the open source license (MIT license) applicable
+ *
+ * to the current version of the project delivered to anyone in the future.
+ */
+
+package actionlb
+
+import (
+	"fmt"
+
+	actcli "hcm/cmd/task-server/logics/action/cli"
+	"hcm/pkg/api/core"
+	hclb "hcm/pkg/api/hc-service/load-balancer"
+	"hcm/pkg/async/action"
+	"hcm/pkg/async/action/run"
+	"hcm/pkg/criteria/enumor"
+	"hcm/pkg/criteria/errf"
+	"hcm/pkg/criteria/validator"
+	"hcm/pkg/dal/dao/tools"
+	"hcm/pkg/kit"
+	"hcm/pkg/logs"
+	"hcm/pkg/tools/assert"
+)
+
+// --------------------------[创建TCloud监听器]-----------------------------
+
+var _ action.Action = new(BatchTaskTCloudCreateListenerAction)
+var _ action.ParameterAction = new(BatchTaskTCloudCreateListenerAction)
+
+// BatchTaskTCloudCreateListenerAction 创建TCloud监听器
+type BatchTaskTCloudCreateListenerAction struct{}
+
+// BatchTaskTCloudCreateListenerOption ...
+type BatchTaskTCloudCreateListenerOption struct {
+	ManagementDetailIDs []string                        `json:"management_detail_ids" validate:"required,min=1,max=20"`
+	Listeners           []*hclb.TCloudListenerCreateReq `json:"Listeners,required,min=1,max=20,dive,required"`
+}
+
+// Validate validate option.
+func (opt BatchTaskTCloudCreateListenerOption) Validate() error {
+	if len(opt.ManagementDetailIDs) != len(opt.Listeners) {
+		return errf.Newf(errf.InvalidParameter, "management_detail_ids and listeners length not match: %d! = %d",
+			len(opt.ManagementDetailIDs), len(opt.Listeners))
+	}
+	return validator.Validate.Struct(opt)
+}
+
+// ParameterNew return request params.
+func (act BatchTaskTCloudCreateListenerAction) ParameterNew() (params any) {
+	return new(BatchTaskTCloudCreateListenerOption)
+}
+
+// Name return action name
+func (act BatchTaskTCloudCreateListenerAction) Name() enumor.ActionName {
+	return enumor.ActionBatchTaskTCloudCreateListener
+}
+
+// Run 创建监听器
+func (act BatchTaskTCloudCreateListenerAction) Run(kt run.ExecuteKit, params any) (result any, taskErr error) {
+	opt, ok := params.(*BatchTaskTCloudCreateListenerOption)
+	if !ok {
+		return nil, errf.New(errf.InvalidParameter, "params type mismatch")
+	}
+
+	results := make([]*hclb.ListenerCreateResult, 0, len(opt.Listeners))
+	for i := range opt.Listeners {
+		detailID := opt.ManagementDetailIDs[i]
+		ret, createErr := act.createSingleListener(kt.Kit(), detailID, opt.Listeners[i]) // 结束后写回状态
+		targetState := enumor.TaskDetailSuccess
+		if createErr != nil {
+			// 更新为失败
+			targetState = enumor.TaskDetailFailed
+		}
+		err := batchUpdateTaskDetailState(kt.Kit(), []string{detailID}, targetState)
+		if err != nil {
+			logs.Errorf("fail to set detail to %s after cloud operation finished, err: %v, rid: %s",
+				targetState, err, kt.Kit().Rid)
+			return nil, err
+		}
+		if createErr != nil {
+			// abort
+			return nil, err
+		}
+		results = append(results, ret)
+	}
+	// all success
+	return results, nil
+}
+
+func (act BatchTaskTCloudCreateListenerAction) createSingleListener(kt *kit.Kit, detailId string,
+	req *hclb.TCloudListenerCreateReq) (*hclb.ListenerCreateResult, error) {
+	detailList, err := listTaskDetail(kt, []string{detailId})
+	if err != nil {
+		logs.Errorf("fail to query task detail, err: %v, rid: %s", err, kt.Rid)
+		return nil, err
+	}
+	detail := detailList[0]
+	if detail.State == enumor.TaskDetailCancel {
+		// 任务被取消，跳过该任务, 直接成功即可
+		return nil, nil
+	}
+	if detail.State != enumor.TaskDetailInit {
+		return nil, errf.Newf(errf.InvalidParameter, "task management detail(%s) status(%s) is not init",
+			detail.ID, detail.State)
+	}
+	exists, err := act.checkListenerExists(kt, req)
+	if err != nil {
+		return nil, err
+	}
+	if exists {
+		// 已存在跳过
+		return nil, nil
+	}
+
+	// 更新任务状态为 running
+	if err := batchUpdateTaskDetailState(kt, []string{detailId}, enumor.TaskDetailRunning); err != nil {
+		return nil, fmt.Errorf("fail to update detail to running, err: %v", err)
+	}
+	lblResp, err := actcli.GetHCService().TCloud.Clb.CreateListener(kt, req)
+	if err != nil {
+		logs.Errorf("fail to call hc to create listener, err: %v, rid: %s", err, kt.Rid)
+		return nil, err
+	}
+	return lblResp, err
+}
+
+func (act BatchTaskTCloudCreateListenerAction) checkListenerExists(kt *kit.Kit,
+	req *hclb.TCloudListenerCreateReq) (exists bool, err error) {
+	// 查询是否已经存在对应监听器
+	lbReq := &core.ListReq{
+		Filter: tools.ExpressionAnd(
+			tools.RuleEqual("vendor", enumor.TCloud),
+			tools.RuleEqual("lb_id", req.LbID),
+			tools.RuleEqual("protocol", req.Protocol),
+			tools.RuleEqual("port", req.Port),
+		),
+		Page: core.NewDefaultBasePage(),
+	}
+	lblResp, err := actcli.GetDataService().TCloud.LoadBalancer.ListListener(kt, lbReq)
+	if err != nil {
+		return false, fmt.Errorf("fail to query listener, err: %v", err)
+	}
+	if len(lblResp.Details) == 0 {
+		return false, nil
+	}
+	// 存在则判断是否和入参一致
+	lbl := lblResp.Details[0]
+
+	if req.Name != lbl.Name {
+		return true, fmt.Errorf("listener(%s) already exist, name mismatch, want: %s, db: %s",
+			lbl.CloudID, req.Name, lbl.Name)
+	}
+	if req.BkBizID != lbl.BkBizID {
+		return true, fmt.Errorf("listener(%s) already exist, biz id mismatch, want: %d, db: %d",
+			lbl.CloudID, req.BkBizID, lbl.BkBizID)
+	}
+	if req.SniSwitch != lbl.SniSwitch {
+		return true, fmt.Errorf("listener(%s) already exist, sni switch mismatch, want: %t, db: %t",
+			lbl.CloudID, req.SniSwitch, lbl.SniSwitch)
+	}
+	if req.EndPort != nil {
+		if lbl.Extension == nil {
+			return true, fmt.Errorf("listener(%s) already exist, session expire mismatch, want: %d, db no ext",
+				lbl.CloudID, req.SessionExpire)
+		}
+		if !assert.IsPtrInt64Equal(lbl.Extension.EndPort, req.EndPort) {
+			return true, fmt.Errorf("listener(%s) already exist, session expire mismatch, want: %+v, db: %+v",
+				lbl.CloudID, req.SessionExpire, lbl.Extension.EndPort)
+		}
+	}
+	if req.Certificate != nil {
+		if lbl.Extension == nil {
+			return true, fmt.Errorf("listener(%s) already exist, cert mismatch, want: %+v, db no ext",
+				lbl.CloudID, req.Certificate)
+		}
+		if isListenerCertChange(req.Certificate, lbl.Extension.Certificate) {
+			return true, fmt.Errorf("listener(%s) already exist, cert mismatch, want: %+v, got: %+v", lbl.CloudID,
+				req.Certificate, lbl.Extension.Certificate)
+		}
+
+	}
+
+	if req.Protocol.IsLayer7Protocol() {
+		return true, nil
+	}
+	// 对于四层需要继续查询规则
+
+	return true, nil
+
+}
+
+// Rollback 支持重入，无需回滚
+func (act BatchTaskTCloudCreateListenerAction) Rollback(kt run.ExecuteKit, params any) error {
+	logs.Infof(" ----------- BatchTaskTCloudCreateListenerAction Rollback -----------, params: %+v, rid: %s",
+		params, kt.Kit().Rid)
+	return nil
+}

--- a/cmd/task-server/logics/action/load-balancer/batch_task_tcloud_create_listener.go
+++ b/cmd/task-server/logics/action/load-balancer/batch_task_tcloud_create_listener.go
@@ -137,7 +137,7 @@ func (act BatchTaskTCloudCreateListenerAction) createSingleListener(kt *kit.Kit,
 		logs.Errorf("fail to call hc to create listener, err: %v, rid: %s", err, kt.Rid)
 		return nil, err
 	}
-	return lblResp, err
+	return lblResp, nil
 }
 
 func (act BatchTaskTCloudCreateListenerAction) checkListenerExists(kt *kit.Kit,

--- a/cmd/task-server/logics/action/load-balancer/bind_targets.go
+++ b/cmd/task-server/logics/action/load-balancer/bind_targets.go
@@ -36,7 +36,7 @@ import (
 var _ action.Action = new(ListenerRuleAddTargetAction)
 var _ action.ParameterAction = new(ListenerRuleAddTargetAction)
 
-// ListenerRuleAddTargetAction 将目标组中的RS应用到监听器或者规则
+// ListenerRuleAddTargetAction 将RS应用到监听器或者规则
 type ListenerRuleAddTargetAction struct{}
 
 // ListenerRuleAddTargetOption ...
@@ -71,7 +71,7 @@ func (act ListenerRuleAddTargetAction) Run(kt run.ExecuteKit, params any) (any, 
 	err := actcli.GetHCService().TCloud.Clb.BatchRegisterTargetToListenerRule(
 		kt.Kit(), opt.LoadBalancerID, opt.BatchRegisterTCloudTargetReq)
 	if err != nil {
-		logs.Errorf("fail to create register target to listener rule, err: %v, rid: %s", err, kt.Kit().Rid)
+		logs.Errorf("fail to register target to listener rule, err: %v, rid: %s", err, kt.Kit().Rid)
 		return nil, err
 	}
 

--- a/cmd/task-server/logics/action/load-balancer/sync_tcloud_load_balancer.go
+++ b/cmd/task-server/logics/action/load-balancer/sync_tcloud_load_balancer.go
@@ -56,7 +56,7 @@ func (act SyncTCloudLoadBalancerAction) ParameterNew() (params any) {
 
 // Name return action name
 func (act SyncTCloudLoadBalancerAction) Name() enumor.ActionName {
-	return enumor.ActionBatchTaskTCloudBindTarget
+	return enumor.ActionSyncTCloudLoadBalancer
 }
 
 // Run 将目标组中的RS绑定到监听器/规则中

--- a/cmd/task-server/logics/action/load-balancer/sync_tcloud_load_balancer.go
+++ b/cmd/task-server/logics/action/load-balancer/sync_tcloud_load_balancer.go
@@ -1,0 +1,83 @@
+/*
+ * TencentBlueKing is pleased to support the open source community by making
+ * 蓝鲸智云 - 混合云管理平台 (BlueKing - Hybrid Cloud Management System) available.
+ * Copyright (C) 2024 THL A29 Limited,
+ * a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * We undertake not to change the open source license (MIT license) applicable
+ *
+ * to the current version of the project delivered to anyone in the future.
+ */
+
+package actionlb
+
+import (
+	actcli "hcm/cmd/task-server/logics/action/cli"
+	"hcm/pkg/api/hc-service/sync"
+	"hcm/pkg/async/action"
+	"hcm/pkg/async/action/run"
+	"hcm/pkg/criteria/enumor"
+	"hcm/pkg/criteria/errf"
+	"hcm/pkg/criteria/validator"
+	"hcm/pkg/logs"
+)
+
+// --------------------------[同步TCloud负载均衡]-----------------------------
+
+var _ action.Action = new(SyncTCloudLoadBalancerAction)
+var _ action.ParameterAction = new(SyncTCloudLoadBalancerAction)
+
+// SyncTCloudLoadBalancerAction 同步TCloud负载均衡
+type SyncTCloudLoadBalancerAction struct{}
+
+// SyncTCloudLoadBalancerOption ...
+type SyncTCloudLoadBalancerOption struct {
+	*sync.TCloudSyncReq `json:",inline" validate:"required"`
+}
+
+// Validate validate option.
+func (opt SyncTCloudLoadBalancerOption) Validate() error {
+
+	return validator.Validate.Struct(opt)
+}
+
+// ParameterNew return request params.
+func (act SyncTCloudLoadBalancerAction) ParameterNew() (params any) {
+	return new(SyncTCloudLoadBalancerOption)
+}
+
+// Name return action name
+func (act SyncTCloudLoadBalancerAction) Name() enumor.ActionName {
+	return enumor.ActionBatchTaskTCloudBindTarget
+}
+
+// Run 将目标组中的RS绑定到监听器/规则中
+func (act SyncTCloudLoadBalancerAction) Run(kt run.ExecuteKit, params any) (result any, taskErr error) {
+	opt, ok := params.(*SyncTCloudLoadBalancerOption)
+	if !ok {
+		return nil, errf.New(errf.InvalidParameter, "params type mismatch")
+	}
+
+	err := actcli.GetHCService().TCloud.Clb.SyncLoadBalancer(kt.Kit(), opt.TCloudSyncReq)
+	if err != nil {
+		logs.Errorf("fail to sync load balancer, err: %v, req: %v rid: %s", err, opt.TCloudSyncReq, kt.Kit().Rid)
+		return nil, err
+	}
+
+	return nil, nil
+}
+
+// Rollback 支持重入，无需回滚
+func (act SyncTCloudLoadBalancerAction) Rollback(kt run.ExecuteKit, params any) error {
+	logs.Infof(" ----------- SyncTCloudLoadBalancerAction Rollback -----------, params: %+v, rid: %s",
+		params, kt.Kit().Rid)
+	return nil
+}

--- a/cmd/task-server/logics/action/load-balancer/sync_tcloud_load_balancer_listener.go
+++ b/cmd/task-server/logics/action/load-balancer/sync_tcloud_load_balancer_listener.go
@@ -1,0 +1,84 @@
+/*
+ * TencentBlueKing is pleased to support the open source community by making
+ * 蓝鲸智云 - 混合云管理平台 (BlueKing - Hybrid Cloud Management System) available.
+ * Copyright (C) 2024 THL A29 Limited,
+ * a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * We undertake not to change the open source license (MIT license) applicable
+ *
+ * to the current version of the project delivered to anyone in the future.
+ */
+
+package actionlb
+
+import (
+	actcli "hcm/cmd/task-server/logics/action/cli"
+	"hcm/pkg/api/hc-service/sync"
+	"hcm/pkg/async/action"
+	"hcm/pkg/async/action/run"
+	"hcm/pkg/criteria/enumor"
+	"hcm/pkg/criteria/errf"
+	"hcm/pkg/criteria/validator"
+	"hcm/pkg/logs"
+)
+
+// --------------------------[同步TCloud负载均衡监听器]-----------------------------
+
+var _ action.Action = new(SyncTCloudLoadBalancerListenerAction)
+var _ action.ParameterAction = new(SyncTCloudLoadBalancerListenerAction)
+
+// SyncTCloudLoadBalancerListenerAction 同步TCloud负载均衡监听器
+type SyncTCloudLoadBalancerListenerAction struct{}
+
+// SyncTCloudLoadBalancerListenerOption ...
+type SyncTCloudLoadBalancerListenerOption struct {
+	*sync.TCloudListenerSyncReq `json:",inline" validate:"required"`
+}
+
+// Validate validate option.
+func (opt SyncTCloudLoadBalancerListenerOption) Validate() error {
+
+	return validator.Validate.Struct(opt)
+}
+
+// ParameterNew return request params.
+func (act SyncTCloudLoadBalancerListenerAction) ParameterNew() (params any) {
+	return new(SyncTCloudLoadBalancerListenerOption)
+}
+
+// Name return action name
+func (act SyncTCloudLoadBalancerListenerAction) Name() enumor.ActionName {
+	return enumor.ActionBatchTaskTCloudBindTarget
+}
+
+// Run 将目标组中的RS绑定到监听器/规则中
+func (act SyncTCloudLoadBalancerListenerAction) Run(kt run.ExecuteKit, params any) (result any, taskErr error) {
+	opt, ok := params.(*SyncTCloudLoadBalancerListenerOption)
+	if !ok {
+		return nil, errf.New(errf.InvalidParameter, "params type mismatch")
+	}
+
+	err := actcli.GetHCService().TCloud.Clb.SyncLoadBalancerListener(kt.Kit(), opt.TCloudListenerSyncReq)
+	if err != nil {
+		logs.Errorf("fail to sync load balancer listener, err: %v, req: %v rid: %s",
+			err, opt.TCloudListenerSyncReq, kt.Kit().Rid)
+		return nil, err
+	}
+
+	return nil, nil
+}
+
+// Rollback 支持重入，无需回滚
+func (act SyncTCloudLoadBalancerListenerAction) Rollback(kt run.ExecuteKit, params any) error {
+	logs.Infof(" ----------- SyncTCloudLoadBalancerListenerAction Rollback -----------, params: %+v, rid: %s",
+		params, kt.Kit().Rid)
+	return nil
+}

--- a/cmd/task-server/logics/action/load-balancer/sync_tcloud_load_balancer_listener.go
+++ b/cmd/task-server/logics/action/load-balancer/sync_tcloud_load_balancer_listener.go
@@ -56,7 +56,7 @@ func (act SyncTCloudLoadBalancerListenerAction) ParameterNew() (params any) {
 
 // Name return action name
 func (act SyncTCloudLoadBalancerListenerAction) Name() enumor.ActionName {
-	return enumor.ActionBatchTaskTCloudBindTarget
+	return enumor.SyncTCloudLoadBalancerListener
 }
 
 // Run 将目标组中的RS绑定到监听器/规则中

--- a/pkg/adaptor/tcloud/listener.go
+++ b/pkg/adaptor/tcloud/listener.go
@@ -573,6 +573,7 @@ func (t *TCloudImpl) DeleteRule(kt *kit.Kit, opt *typelb.TCloudDeleteRuleOption)
 
 // RegisterTargets 批量绑定虚拟主机或弹性网卡 reference: https://cloud.tencent.com/document/api/214/38303
 // 批量绑定的资源数量上限为500。只支持VPC网络负载均衡。
+// 支持重入，但是如果已绑定RS数量+待绑定数量 大于限额会报错，即使待绑定的rs是已经绑定的rs重复绑定
 // 返回绑定失败的监听器ID，如为空表示全部绑定成功。
 func (t *TCloudImpl) RegisterTargets(kt *kit.Kit, opt *typelb.TCloudRegisterTargetsOption) ([]string, error) {
 	if opt == nil {

--- a/pkg/api/core/response.go
+++ b/pkg/api/core/response.go
@@ -51,3 +51,11 @@ type BaseResp[T any] struct {
 	rest.BaseResp `json:",inline"`
 	Data          T `json:"data"`
 }
+
+// CloudCreateResult 调用云上接口创建结果
+type CloudCreateResult struct {
+	// 本地ID，可能为空
+	ID string `json:"id"`
+	// 云上ID
+	CloudID string `json:"cloud_id"`
+}

--- a/pkg/api/hc-service/load-balancer/tcloud.go
+++ b/pkg/api/hc-service/load-balancer/tcloud.go
@@ -29,6 +29,7 @@ import (
 	"hcm/pkg/api/data-service/cloud"
 	"hcm/pkg/criteria/constant"
 	"hcm/pkg/criteria/enumor"
+	"hcm/pkg/criteria/errf"
 	"hcm/pkg/criteria/validator"
 	"hcm/pkg/tools/converter"
 )
@@ -283,6 +284,46 @@ func (r TCloudRuleDeleteByDomainReq) Validate() error {
 
 // --------------------------[创建监听器及规则]--------------------------
 
+// ListenerCreateReq listener only create req.
+type ListenerCreateReq struct {
+	Name          string                        `json:"name" validate:"required"`
+	BkBizID       int64                         `json:"bk_biz_id" validate:"omitempty"`
+	LbID          string                        `json:"lb_id" validate:"required"`
+	Protocol      enumor.ProtocolType           `json:"protocol" validate:"required"`
+	Port          int64                         `json:"port" validate:"required"`
+	Scheduler     string                        `json:"scheduler" validate:"required"`
+	SessionType   string                        `json:"session_type" validate:"required"`
+	SessionExpire int64                         `json:"session_expire" validate:"omitempty"`
+	SniSwitch     enumor.SniType                `json:"sni_switch" validate:"omitempty"`
+	Certificate   *corelb.TCloudCertificateInfo `json:"certificate" validate:"omitempty"`
+	EndPort       *int64                        `json:"end_port" validate:"omitempty,min=1"`
+}
+
+// Validate 校验创建监听器的参数
+func (req *ListenerCreateReq) Validate() error {
+
+	if req.SessionExpire > 0 && (req.SessionExpire < 30 || req.SessionExpire > 3600) {
+		return errors.New("session_expire must be '0' or between `30` and `3600`")
+	}
+
+	// 7层HTTPS 监听器 SNI开启，不能传入证书，SNI关闭时，需要传入证书
+	if req.Protocol == enumor.HttpsProtocol {
+		if req.SniSwitch == enumor.SniTypeClose && req.Certificate == nil {
+			return errf.New(errf.InvalidParameter, "certificate is required for non-sni https listener")
+		}
+		if req.SniSwitch == enumor.SniTypeClose && converter.PtrToVal(req.Certificate.CaCloudID) == "" && len(req.
+			Certificate.CertCloudIDs) == 0 {
+			return errf.New(errf.InvalidParameter,
+				"certificate.ca_cloud_id/certificate.cert_cloud_ids is required for non-sni https listener")
+		}
+		if req.SniSwitch == enumor.SniTypeOpen && req.Certificate != nil {
+			return errf.New(errf.InvalidParameter, "certificate should not exists for sni https listener")
+		}
+	}
+
+	return validator.Validate.Struct(req)
+}
+
 // ListenerWithRuleCreateReq listener with rule create req.
 type ListenerWithRuleCreateReq struct {
 	Name          string                        `json:"name" validate:"required"`
@@ -318,6 +359,12 @@ func (req *ListenerWithRuleCreateReq) Validate() error {
 type ListenerWithRuleCreateResult struct {
 	CloudLblID  string `json:"cloud_lbl_id"`
 	CloudRuleID string `json:"cloud_rule_id"`
+}
+
+// ListenerCreateResult 监听器创建结果
+type ListenerCreateResult struct {
+	LblID      string `json:"lbl_id"`
+	CloudLblID string `json:"cloud_lbl_id"`
 }
 
 // --------------------------[更新监听器]--------------------------

--- a/pkg/api/hc-service/load-balancer/tcloud.go
+++ b/pkg/api/hc-service/load-balancer/tcloud.go
@@ -25,6 +25,7 @@ import (
 
 	"hcm/pkg/adaptor/types/core"
 	typelb "hcm/pkg/adaptor/types/load-balancer"
+	apicore "hcm/pkg/api/core"
 	corelb "hcm/pkg/api/core/cloud/load-balancer"
 	"hcm/pkg/api/data-service/cloud"
 	"hcm/pkg/criteria/constant"
@@ -362,10 +363,7 @@ type ListenerWithRuleCreateResult struct {
 }
 
 // ListenerCreateResult 监听器创建结果
-type ListenerCreateResult struct {
-	LblID      string `json:"lbl_id"`
-	CloudLblID string `json:"cloud_lbl_id"`
-}
+type ListenerCreateResult = apicore.CloudCreateResult
 
 // --------------------------[更新监听器]--------------------------
 

--- a/pkg/api/hc-service/load-balancer/tcloud.go
+++ b/pkg/api/hc-service/load-balancer/tcloud.go
@@ -291,11 +291,11 @@ type TCloudListenerCreateReq struct {
 	LbID          string                        `json:"lb_id" validate:"required"`
 	Protocol      enumor.ProtocolType           `json:"protocol" validate:"required"`
 	Port          int64                         `json:"port" validate:"required"`
-	Scheduler     string                        `json:"scheduler" validate:"required"`
-	SessionType   string                        `json:"session_type" validate:"required"`
+	Scheduler     string                        `json:"scheduler" validate:"omitempty"`
 	SessionExpire int64                         `json:"session_expire" validate:"omitempty"`
 	SniSwitch     enumor.SniType                `json:"sni_switch" validate:"omitempty"`
 	Certificate   *corelb.TCloudCertificateInfo `json:"certificate" validate:"omitempty"`
+	SessionType   *string                       `json:"session_type" validate:"omitempty"`
 	EndPort       *int64                        `json:"end_port" validate:"omitempty,min=1"`
 }
 

--- a/pkg/api/hc-service/load-balancer/tcloud.go
+++ b/pkg/api/hc-service/load-balancer/tcloud.go
@@ -284,8 +284,8 @@ func (r TCloudRuleDeleteByDomainReq) Validate() error {
 
 // --------------------------[创建监听器及规则]--------------------------
 
-// ListenerCreateReq listener only create req.
-type ListenerCreateReq struct {
+// TCloudListenerCreateReq listener only create req.
+type TCloudListenerCreateReq struct {
 	Name          string                        `json:"name" validate:"required"`
 	BkBizID       int64                         `json:"bk_biz_id" validate:"omitempty"`
 	LbID          string                        `json:"lb_id" validate:"required"`
@@ -300,7 +300,7 @@ type ListenerCreateReq struct {
 }
 
 // Validate 校验创建监听器的参数
-func (req *ListenerCreateReq) Validate() error {
+func (req *TCloudListenerCreateReq) Validate() error {
 
 	if req.SessionExpire > 0 && (req.SessionExpire < 30 || req.SessionExpire > 3600) {
 		return errors.New("session_expire must be '0' or between `30` and `3600`")

--- a/pkg/api/hc-service/sync/sync.go
+++ b/pkg/api/hc-service/sync/sync.go
@@ -34,8 +34,9 @@ func (req *TCloudGlobalSyncReq) Validate() error {
 
 // TCloudSyncReq tcloud sync request
 type TCloudSyncReq struct {
-	AccountID string `json:"account_id" validate:"required"`
-	Region    string `json:"region" validate:"required"`
+	AccountID string   `json:"account_id" validate:"required"`
+	Region    string   `json:"region" validate:"required"`
+	CloudIds  []string `json:"cloud_ids" validate:"omitempty,max=20"`
 }
 
 // Validate tcloud sync request.

--- a/pkg/api/hc-service/sync/sync.go
+++ b/pkg/api/hc-service/sync/sync.go
@@ -34,9 +34,10 @@ func (req *TCloudGlobalSyncReq) Validate() error {
 
 // TCloudSyncReq tcloud sync request
 type TCloudSyncReq struct {
-	AccountID string   `json:"account_id" validate:"required"`
-	Region    string   `json:"region" validate:"required"`
-	CloudIds  []string `json:"cloud_ids" validate:"omitempty,max=20"`
+	AccountID string `json:"account_id" validate:"required"`
+	Region    string `json:"region" validate:"required"`
+	// 传入指定资源id进行同步，仅特定资源支持
+	CloudIDs []string `json:"cloud_ids" validate:"omitempty,max=20"`
 }
 
 // Validate tcloud sync request.
@@ -208,10 +209,11 @@ func (req *AzureImageReq) Validate() error {
 
 // TCloudListenerSyncReq 监听器同步
 type TCloudListenerSyncReq struct {
-	AccountID           string   `json:"account_id" validate:"required"`
-	Region              string   `json:"region" validate:"required"`
-	LoadBalancerCloudID string   `json:"lb_cloud_id" validate:"required"`
-	ListenerCloudIds    []string `json:"lbl_cloud_ids" validate:"omitempty"`
+	AccountID           string `json:"account_id" validate:"required"`
+	Region              string `json:"region" validate:"required"`
+	LoadBalancerCloudID string `json:"lb_cloud_id" validate:"required"`
+	// 支持传入指定监听器id同步
+	CloudIDs []string `json:"lbl_cloud_ids" validate:"omitempty,max=20"`
 }
 
 // Validate ...

--- a/pkg/async/consumer/executor.go
+++ b/pkg/async/consumer/executor.go
@@ -190,18 +190,18 @@ func (exec *executor) workerDo(task *Task) (err error) {
 			return
 		}
 		err = runErr
-		logs.Errorf("task run failed, err: %v, task: %+v, result: %+v, rid: %s",
-			runErr, task, failedRet, exec.kt.Rid)
+		logs.Errorf("task %s run failed, err: %v, task: %+v, result: %+v, rid: %s",
+			task.ID, runErr, task, failedRet, exec.kt.Rid)
 		if errf.IsContextCanceled(runErr) {
 			task.State = enumor.TaskCancel
 			return
 		}
 		nextState := enumor.TaskFailed
 		if patchErr := exec.UpdateTask(task, nextState, runErr.Error(), failedRet); patchErr != nil {
-			logs.Errorf("task set %s state failed after run failed, err: %v, patchErr: %v, exeRid: %s, "+
-				"taskRid: %s", nextState, runErr, patchErr, exec.kt.Rid, task.Kit.Rid)
-			err = fmt.Errorf("task set %s state failed, after run failed, err: %v, patchErr: %v",
-				nextState, runErr, patchErr)
+			logs.Errorf("task %s set %s state failed after run failed, err: %v, patchErr: %v, exeRid: %s, taskRid: %s",
+				task.ID, nextState, runErr, patchErr, exec.kt.Rid, task.Kit.Rid)
+			err = fmt.Errorf("task %s set %s state failed, after run failed, err: %v, patchErr: %v",
+				task.ID, nextState, runErr, patchErr)
 			return
 		}
 		return

--- a/pkg/client/hc-service/tcloud/clb.go
+++ b/pkg/client/hc-service/tcloud/clb.go
@@ -81,10 +81,10 @@ func (c *ClbClient) CreateListenerWithTargetGroup(kt *kit.Kit, req *hcproto.List
 }
 
 // CreateListener 创建监听器自身
-func (c *ClbClient) CreateListener(kt *kit.Kit, req *hcproto.ListenerCreateReq) (
+func (c *ClbClient) CreateListener(kt *kit.Kit, req *hcproto.TCloudListenerCreateReq) (
 	*hcproto.ListenerCreateResult, error) {
 
-	return common.Request[hcproto.ListenerCreateReq, hcproto.ListenerCreateResult](
+	return common.Request[hcproto.TCloudListenerCreateReq, hcproto.ListenerCreateResult](
 		c.client, http.MethodPost, kt, req, "/listeners/create")
 }
 

--- a/pkg/client/hc-service/tcloud/clb.go
+++ b/pkg/client/hc-service/tcloud/clb.go
@@ -47,8 +47,12 @@ type ClbClient struct {
 
 // SyncLoadBalancer 同步负载均衡
 func (c *ClbClient) SyncLoadBalancer(kt *kit.Kit, req *sync.TCloudSyncReq) error {
-
 	return common.RequestNoResp[sync.TCloudSyncReq](c.client, http.MethodPost, kt, req, "/load_balancers/sync")
+}
+
+// SyncLoadBalancerListener 同步负载均衡下监听器
+func (c *ClbClient) SyncLoadBalancerListener(kt *kit.Kit, req *sync.TCloudListenerSyncReq) error {
+	return common.RequestNoResp[sync.TCloudListenerSyncReq](c.client, http.MethodPost, kt, req, "/listeners/sync")
 }
 
 // DescribeResources ...

--- a/pkg/client/hc-service/tcloud/clb.go
+++ b/pkg/client/hc-service/tcloud/clb.go
@@ -72,12 +72,12 @@ func (c *ClbClient) Update(kt *kit.Kit, id string, req *hcproto.TCloudLBUpdateRe
 		kt, req, "/load_balancers/%s", id)
 }
 
-// CreateListener 创建监听器
-func (c *ClbClient) CreateListener(kt *kit.Kit, req *hcproto.ListenerWithRuleCreateReq) (
+// CreateListenerWithTargetGroup 创建监听器和规则并绑定目标组
+func (c *ClbClient) CreateListenerWithTargetGroup(kt *kit.Kit, req *hcproto.ListenerWithRuleCreateReq) (
 	*hcproto.ListenerWithRuleCreateResult, error) {
 
 	return common.Request[hcproto.ListenerWithRuleCreateReq, hcproto.ListenerWithRuleCreateResult](
-		c.client, http.MethodPost, kt, req, "/listeners/create")
+		c.client, http.MethodPost, kt, req, "/listeners/create_with_rule")
 }
 
 // UpdateListener 更新监听器

--- a/pkg/client/hc-service/tcloud/clb.go
+++ b/pkg/client/hc-service/tcloud/clb.go
@@ -80,6 +80,14 @@ func (c *ClbClient) CreateListenerWithTargetGroup(kt *kit.Kit, req *hcproto.List
 		c.client, http.MethodPost, kt, req, "/listeners/create_with_rule")
 }
 
+// CreateListener 创建监听器自身
+func (c *ClbClient) CreateListener(kt *kit.Kit, req *hcproto.ListenerCreateReq) (
+	*hcproto.ListenerCreateResult, error) {
+
+	return common.Request[hcproto.ListenerCreateReq, hcproto.ListenerCreateResult](
+		c.client, http.MethodPost, kt, req, "/listeners/create")
+}
+
 // UpdateListener 更新监听器
 func (c *ClbClient) UpdateListener(kt *kit.Kit, id string, req *hcproto.ListenerWithRuleUpdateReq) (
 	*hcproto.BatchCreateResult, error) {

--- a/pkg/criteria/enumor/async_task_name.go
+++ b/pkg/criteria/enumor/async_task_name.go
@@ -45,6 +45,7 @@ func (v ActionName) Validate() error {
 	case ActionPullDailyRawBill, ActionMainAccountSummary, ActionRootAccountSummary,
 		ActionDailyAccountSplit, ActionDailyAccountSummary, ActionMonthTaskAction:
 	case ActionLoadBalancerDeleteUrlRule, ActionLoadBalancerDeleteListener:
+	case ActionBatchTaskTCloudCreateL7Rule, ActionBatchTaskTCloudBindTarget, ActionBatchTaskTCloudCreateListener:
 
 	default:
 		return fmt.Errorf("unsupported action name type: %s", v)
@@ -129,4 +130,13 @@ const (
 	ActionDailyAccountSplit   = "bill_daily_account_split"
 	ActionDailyAccountSummary = "bill_daily_account_summary"
 	ActionMonthTaskAction     = "bill_month_task"
+)
+
+const (
+	// ActionBatchTaskTCloudBindTarget ...
+	ActionBatchTaskTCloudBindTarget = "batch_task_tcloud_bind_target"
+	// ActionBatchTaskTCloudCreateListener ...
+	ActionBatchTaskTCloudCreateListener = "batch_task_tcloud_create_listener"
+	// ActionBatchTaskTCloudCreateL7Rule ...
+	ActionBatchTaskTCloudCreateL7Rule = "batch_task_tcloud_create_l7_rule"
 )

--- a/pkg/criteria/enumor/async_task_name.go
+++ b/pkg/criteria/enumor/async_task_name.go
@@ -140,3 +140,10 @@ const (
 	// ActionBatchTaskTCloudCreateL7Rule ...
 	ActionBatchTaskTCloudCreateL7Rule = "batch_task_tcloud_create_l7_rule"
 )
+
+const (
+	// ActionSyncTCloudLoadBalancer ...
+	ActionSyncTCloudLoadBalancer = "sync_tcloud_load_balancer"
+	// SyncTCloudLoadBalancerListener ...
+	SyncTCloudLoadBalancerListener = "sync_tcloud_load_balancer_listener"
+)

--- a/pkg/tools/retry/retry.go
+++ b/pkg/tools/retry/retry.go
@@ -120,5 +120,5 @@ func (r *RetryPolicy) BaseExec(kt *kit.Kit, retryFunc func() error) error {
 		return nil
 	}
 
-	return fmt.Errorf("execute retry func over maximum number of retries: %d, lastErr: %v", r.immuneCount, lastErr)
+	return fmt.Errorf("execute failed after %d retries, lastErr: %v", r.immuneCount, lastErr)
 }


### PR DESCRIPTION
## 1. 批量任务原子：
1. 创建4层/7层 单监听器
2. 创建7层规则
3. 绑定4层/7层RS
4. 负载均衡同步
5. 负载均衡监听器同步

## 2. 其他CLB功能
1. HCService 纯监听器创建接口
2. HCService 负载均衡、监听器 支持指定资源id同步
3. 删除负载均衡结果补充轮询
4. 支持创建超过500个rs的监听器