### PR TITLE
feat: AWS-支持使用日期不在本账单月份的账单，优化异步任务查询sql

### DIFF
--- a/cmd/account-server/logics/bill/monthtask/aws.go
+++ b/cmd/account-server/logics/bill/monthtask/aws.go
@@ -28,15 +28,44 @@ import (
 )
 
 func init() {
-	monthTaskDescriberRegistry[enumor.Aws] = &AwsMonthDescriber{}
+	monthTaskDescriberRegistry[enumor.Aws] = NewAwsMonthDescriber
 }
 
-// AwsMonthDescriber aws month task describer
-type AwsMonthDescriber struct {
+// NewAwsMonthDescriber ...
+func NewAwsMonthDescriber(rootAccountCloudID string) MonthTaskDescriber {
+	describer := &awsMonthDescriber{RootAccountCloudID: rootAccountCloudID}
+	// set exclude account id
+	describer.CommonExpenseExcludeCloudIDs = cc.AccountServer().BillAllocation.AwsCommonExpense.ExcludeAccountCloudIDs
+	// matching saving plan allocation option
+	for _, spOpt := range cc.AccountServer().BillAllocation.AwsSavingsPlans {
+		if spOpt.RootAccountCloudID != rootAccountCloudID {
+			continue
+		}
+		describer.SpAccountCloudID = spOpt.SpPurchaseAccountCloudID
+		describer.SpArnPrefix = spOpt.SpArnPrefix
+	}
+
+	return describer
+}
+
+// awsMonthDescriber aws month task describer
+type awsMonthDescriber struct {
+	RootAccountCloudID           string
+	SpArnPrefix                  string
+	SpAccountCloudID             string
+	CommonExpenseExcludeCloudIDs []string
 }
 
 // GetMonthTaskTypes aws month tasks
-func (aws *AwsMonthDescriber) GetMonthTaskTypes() []enumor.MonthTaskType {
+func (aws *awsMonthDescriber) GetMonthTaskTypes() []enumor.MonthTaskType {
+	if aws.SpArnPrefix == "" {
+		return []enumor.MonthTaskType{
+			enumor.AwsOutsideBillMonthTask,
+			// 没有配置sp前缀则不生成对应的sp分账任务
+			// enumor.AwsSavingsPlansMonthTask,
+			enumor.AwsSupportMonthTask,
+		}
+	}
 	return []enumor.MonthTaskType{
 		enumor.AwsOutsideBillMonthTask,
 		enumor.AwsSavingsPlansMonthTask,
@@ -45,22 +74,11 @@ func (aws *AwsMonthDescriber) GetMonthTaskTypes() []enumor.MonthTaskType {
 }
 
 // GetTaskExtension extension for task
-func (aws *AwsMonthDescriber) GetTaskExtension(rootAccountCloudID string) (map[string]string, error) {
-	// set exclude account id
-	excludeCloudIds := cc.AccountServer().BillAllocation.AwsCommonExpense.ExcludeAccountCloudIDs
-	var spArnPrefix, spAccountCloudID string
-	// matching saving plan allocation option
-	for _, spOpt := range cc.AccountServer().BillAllocation.AwsSavingsPlans {
-		if spOpt.RootAccountCloudID != rootAccountCloudID {
-			continue
-		}
-		spAccountCloudID = spOpt.SpPurchaseAccountCloudID
-		spArnPrefix = spOpt.SpArnPrefix
-	}
+func (aws *awsMonthDescriber) GetTaskExtension() (map[string]string, error) {
 
 	return map[string]string{
-		constant.AwsCommonExpenseExcludeCloudIDKey: strings.Join(excludeCloudIds, ","),
-		constant.AwsSavingsPlanARNPrefixKey:        spArnPrefix,
-		constant.AwsSavingsPlanAccountCloudIDKey:   spAccountCloudID,
+		constant.AwsCommonExpenseExcludeCloudIDKey: strings.Join(aws.CommonExpenseExcludeCloudIDs, ","),
+		constant.AwsSavingsPlanARNPrefixKey:        aws.SpArnPrefix,
+		constant.AwsSavingsPlanAccountCloudIDKey:   aws.SpAccountCloudID,
 	}, nil
 }

--- a/cmd/account-server/logics/bill/monthtask/aws.go
+++ b/cmd/account-server/logics/bill/monthtask/aws.go
@@ -37,7 +37,11 @@ type AwsMonthDescriber struct {
 
 // GetMonthTaskTypes aws month tasks
 func (aws *AwsMonthDescriber) GetMonthTaskTypes() []enumor.MonthTaskType {
-	return []enumor.MonthTaskType{enumor.AwsSavingsPlansMonthTask, enumor.AwsSupportMonthTask}
+	return []enumor.MonthTaskType{
+		enumor.AwsOutsideBillMonthTask,
+		enumor.AwsSavingsPlansMonthTask,
+		enumor.AwsSupportMonthTask,
+	}
 }
 
 // GetTaskExtension extension for task

--- a/cmd/account-server/logics/bill/monthtask/monthtask.go
+++ b/cmd/account-server/logics/bill/monthtask/monthtask.go
@@ -128,7 +128,6 @@ func (r *DefaultMonthTaskRunner) EnsureMonthTask(kt *kit.Kit, billYear, billMont
 			r.rootAccountID, r.vendor, err, kt.Rid)
 		return err
 	}
-
 	logs.Infof("[%s] %s(%s) %d-%02d monthtask setting extension: %v, rid: %s",
 		r.vendor, r.rootAccountCloudID, r.rootAccountID, billYear, billMonth, r.ext, kt.Rid)
 
@@ -143,7 +142,13 @@ func (r *DefaultMonthTaskRunner) EnsureMonthTask(kt *kit.Kit, billYear, billMont
 		return nil
 	}
 	// 进入 月度任务执行阶段
-	monthTasks, err := r.listMonthPullTaskStub(kt, billYear, billMonth)
+	return r.executeMonthTask(kt, monthDescriber, rootSummary)
+}
+
+func (r *DefaultMonthTaskRunner) executeMonthTask(kt *kit.Kit, monthDescriber MonthTaskDescriber,
+	rootSummary *billcore.SummaryRoot) error {
+
+	monthTasks, err := r.listMonthPullTaskStub(kt, rootSummary.BillYear, rootSummary.BillMonth)
 	if err != nil {
 		logs.Errorf("list month task stub for ensuring month task failed, err: %v, rid: %s", err, kt.Rid)
 		return err
@@ -165,7 +170,7 @@ func (r *DefaultMonthTaskRunner) EnsureMonthTask(kt *kit.Kit, billYear, billMont
 		}
 		// 判断versionID是否一致，不一致，则重新创建month task
 		if monthTask.VersionID != rootSummary.CurrentVersion {
-			if err := r.deleteMonthPullTaskStub(kt, billYear, billMonth, curType); err != nil {
+			if err := r.deleteMonthPullTaskStub(kt, rootSummary.BillYear, rootSummary.BillMonth, curType); err != nil {
 				return err
 			}
 			return r.createMonthPullTaskStub(kt, rootSummary, curType)
@@ -191,7 +196,6 @@ func (r *DefaultMonthTaskRunner) EnsureMonthTask(kt *kit.Kit, billYear, billMont
 			continue
 		}
 	}
-
 	return nil
 }
 

--- a/cmd/account-server/logics/bill/rootaccount_controller.go
+++ b/cmd/account-server/logics/bill/rootaccount_controller.go
@@ -25,7 +25,7 @@ import (
 	"math/rand"
 	"time"
 
-	monthtask2 "hcm/cmd/account-server/logics/bill/monthtask"
+	monthtask "hcm/cmd/account-server/logics/bill/monthtask"
 	"hcm/cmd/task-server/logics/action/bill/rootsummary"
 	"hcm/pkg/api/core"
 	billcore "hcm/pkg/api/core/bill"
@@ -152,7 +152,7 @@ func (rac *RootAccountController) runMonthTaskLoop(kt *kit.Kit) {
 
 	ticker := time.NewTicker(*cc.AccountServer().Controller.RootAccountSummarySyncDuration)
 	for {
-		runner := monthtask2.NewDefaultMonthTaskRunner(kt,
+		runner := monthtask.NewDefaultMonthTaskRunner(kt,
 			rac.Vendor, rac.RootAccountID, rac.RootAccountCloudID, rac.Client)
 		select {
 		case <-ticker.C:

--- a/cmd/hc-service/service/bill/bill.go
+++ b/cmd/hc-service/service/bill/bill.go
@@ -61,6 +61,8 @@ func InitBillService(cap *capability.Capability) {
 		"/vendors/azure/root_account_bills/list", v.AzureGetRootAccountBillList)
 	h.Add("AwsGetRootAccountSpTotalUsage", "GET",
 		"/vendors/aws/root_account_bills/sp_usage_total", v.AwsGetRootAccountSpTotalUsage)
+	h.Add("AwsListRootOutsideMonthBill", "GET",
+		"/vendors/aws/root_account_bills/list_outside_month_bills", v.AwsListRootOutsideMonthBill)
 
 	h.Load(cap.WebService)
 }

--- a/cmd/task-server/logics/action/bill/mainsummary/mainsummary.go
+++ b/cmd/task-server/logics/action/bill/mainsummary/mainsummary.go
@@ -219,8 +219,9 @@ func (act *MainAccountSummaryAction) getExchangeRate(
 func (act *MainAccountSummaryAction) calculateMonthTaskStatus(kt *kit.Kit, summaryRoot *billcore.SummaryRoot,
 	summary *bill.BillSummaryMain) (extraCost decimal.Decimal, isFinished bool, err error) {
 
-	monthDescriber, ok := monthtask.GetMonthTaskDescriber(summaryRoot.Vendor)
-	if !ok {
+	monthDescriber := monthtask.GetMonthTaskDescriber(summaryRoot.Vendor, summaryRoot.RootAccountCloudID)
+	if monthDescriber == nil {
+		// unsupported, skip
 		return decimal.Zero, true, nil
 	}
 

--- a/cmd/task-server/logics/action/bill/monthtask/aws.go
+++ b/cmd/task-server/logics/action/bill/monthtask/aws.go
@@ -94,6 +94,9 @@ func (a awsMonthTaskBaseRunner) listMainAccount(kt *kit.Kit, rootAccount *datapr
 			rootAsMainAccount = account
 		}
 	}
+	if rootAsMainAccount == nil {
+		return nil, nil, errors.New("can not found root as main account " + rootAccount.CloudID)
+	}
 
 	return mainAccountMap, rootAsMainAccount, nil
 }

--- a/cmd/task-server/logics/action/bill/monthtask/aws.go
+++ b/cmd/task-server/logics/action/bill/monthtask/aws.go
@@ -41,6 +41,8 @@ import (
 
 func newAwsRunner(taskType enumor.MonthTaskType) (MonthTaskRunner, error) {
 	switch taskType {
+	case enumor.AwsOutsideBillMonthTask:
+		return &AwsOutsideBillMonthTask{}, nil
 	case enumor.AwsSupportMonthTask:
 		return &AwsSupportMonthTask{}, nil
 	case enumor.AwsSavingsPlansMonthTask:

--- a/cmd/task-server/logics/action/bill/monthtask/aws_outside_bill_month.go
+++ b/cmd/task-server/logics/action/bill/monthtask/aws_outside_bill_month.go
@@ -1,0 +1,174 @@
+/*
+ * TencentBlueKing is pleased to support the open source community by making
+ * 蓝鲸智云 - 混合云管理平台 (BlueKing - Hybrid Cloud Management System) available.
+ * Copyright (C) 2024 THL A29 Limited,
+ * a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * We undertake not to change the open source license (MIT license) applicable
+ *
+ * to the current version of the project delivered to anyone in the future.
+ */
+
+package monthtask
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/tidwall/gjson"
+
+	actcli "hcm/cmd/task-server/logics/action/cli"
+	"hcm/pkg/api/core"
+	"hcm/pkg/api/data-service/bill"
+	hcbill "hcm/pkg/api/hc-service/bill"
+	"hcm/pkg/criteria/constant"
+	"hcm/pkg/criteria/enumor"
+	"hcm/pkg/dal/dao/tools"
+	"hcm/pkg/dal/table/types"
+	"hcm/pkg/kit"
+	"hcm/pkg/logs"
+	cvt "hcm/pkg/tools/converter"
+)
+
+// AwsOutsideBillMonthTask ...
+type AwsOutsideBillMonthTask struct {
+	awsMonthTaskBaseRunner
+}
+
+// Pull outside bill month item
+func (a AwsOutsideBillMonthTask) Pull(kt *kit.Kit, opt *MonthTaskActionOption, index uint64) (
+	itemList []bill.RawBillItem, isFinished bool, err error) {
+
+	rootBillReq := &hcbill.AwsRootOutsideMonthBillListReq{
+		RootAccountID: opt.RootAccountID,
+		BillYear:      uint(opt.BillYear),
+		BillMonth:     uint(opt.BillMonth),
+		Page:          &hcbill.AwsBillListPage{Offset: index, Limit: a.GetBatchSize(kt)},
+	}
+	billResp, err := actcli.GetHCService().Aws.Bill.ListRootOutsideMonthBill(kt, rootBillReq)
+	if err != nil {
+		return nil, false, err
+	}
+	if len(billResp.Details) == 0 {
+		return nil, true, nil
+	}
+	for _, record := range billResp.Details {
+		cost, err := getDecimal(record, "line_item_net_unblended_cost")
+		if err != nil {
+			return nil, false, err
+		}
+		amount, err := getDecimal(record, "line_item_usage_amount")
+		if err != nil {
+			return nil, false, err
+		}
+
+		extensionBytes, err := json.Marshal(record)
+		if err != nil {
+			return nil, false, fmt.Errorf("marshal aws bill item %v failed, err: %w", record, err)
+		}
+		itemList = append(itemList, bill.RawBillItem{
+			Region:        record["product_region"],
+			HcProductCode: record["line_item_product_code"],
+			HcProductName: record["product_product_name"],
+			BillCurrency:  enumor.CurrencyCode(record["line_item_currency_code"]),
+			BillCost:      cvt.PtrToVal(cost),
+			ResAmount:     cvt.PtrToVal(amount),
+			ResAmountUnit: record["pricing_unit"],
+			Extension:     types.JsonField(extensionBytes),
+		})
+	}
+	supportDone := uint64(len(billResp.Details)) < a.GetBatchSize(kt)
+	return itemList, supportDone, nil
+}
+
+// Split aws support fee to main account
+func (a AwsOutsideBillMonthTask) Split(kt *kit.Kit, opt *MonthTaskActionOption,
+	rawItemList []*bill.RawBillItem) ([]bill.BillItemCreateReq[json.RawMessage], error) {
+
+	if len(rawItemList) == 0 {
+		return nil, nil
+	}
+	a.initExtension(opt)
+
+	cloudIdSummaryMainMap, err := a.listSummaryMains(kt, opt)
+	if err != nil {
+		logs.Errorf("fail to list summary main for spilt outside bill month, err: %v, rid: %s", err, kt.Rid)
+		return nil, err
+	}
+
+	// 按实际使用账号分摊到对应账号下即可
+	billItems := make([]bill.BillItemCreateReq[json.RawMessage], 0, len(rawItemList))
+	for i := range rawItemList {
+		item := rawItemList[i]
+		accountCloudId := gjson.Get(string(item.Extension), "line_item_usage_account_id").String()
+		if len(accountCloudId) == 0 {
+			return nil, fmt.Errorf("empty line item usage account id for idx: %d", i)
+		}
+		summaryMain := cloudIdSummaryMainMap[accountCloudId]
+		if summaryMain == nil {
+			logs.Errorf("can not found main account(%s) for aws outside month bill split, rid: %s",
+				accountCloudId, kt.Rid)
+			return nil, fmt.Errorf("can not found main account(%s) for aws outside month bill split", accountCloudId)
+		}
+		usageBillItem := bill.BillItemCreateReq[json.RawMessage]{
+			RootAccountID: opt.RootAccountID,
+			MainAccountID: summaryMain.MainAccountCloudID,
+			Vendor:        opt.Vendor,
+			ProductID:     summaryMain.ProductID,
+			BkBizID:       summaryMain.BkBizID,
+			BillYear:      opt.BillYear,
+			BillMonth:     opt.BillMonth,
+			BillDay:       enumor.MonthTaskSpecialBillDay,
+			VersionID:     summaryMain.CurrentVersion,
+			Currency:      item.BillCurrency,
+			Cost:          item.BillCost,
+			HcProductCode: constant.BillOutsideMonthBillName,
+			HcProductName: item.HcProductName,
+			ResAmount:     item.ResAmount,
+			ResAmountUnit: item.ResAmountUnit,
+			Extension:     cvt.ValToPtr(json.RawMessage(item.Extension)),
+		}
+		billItems = append(billItems, usageBillItem)
+	}
+
+	return billItems, nil
+}
+
+// 获取summary信息
+func (a AwsOutsideBillMonthTask) listSummaryMains(kt *kit.Kit, opt *MonthTaskActionOption) (
+	map[string]*bill.BillSummaryMain, error) {
+
+	summaryListReq := &bill.BillSummaryMainListReq{
+		Filter: tools.ExpressionAnd(
+			tools.RuleEqual("root_account_id", opt.RootAccountID),
+			tools.RuleEqual("bill_year", opt.BillYear),
+			tools.RuleEqual("bill_month", opt.BillMonth),
+		),
+		Page: core.NewDefaultBasePage(),
+	}
+	summaryMainResp, err := actcli.GetDataService().Global.Bill.ListBillSummaryMain(kt, summaryListReq)
+	if err != nil {
+		logs.Errorf("failt to list main account bill summary for %s month task, err: %v, rid: %s",
+			enumor.Aws, err, kt.Rid)
+		return nil, err
+	}
+	summaryMap := make(map[string]*bill.BillSummaryMain, len(summaryMainResp.Details))
+	for i := range summaryMainResp.Details {
+		s := summaryMainResp.Details[i]
+		summaryMap[s.MainAccountCloudID] = s
+	}
+	return summaryMap, nil
+}
+
+// GetHcProductCodes hc product code ranges
+func (a *AwsOutsideBillMonthTask) GetHcProductCodes() []string {
+	return []string{constant.BillOutsideMonthBillName}
+}

--- a/cmd/task-server/logics/action/bill/monthtask/aws_outside_bill_month.go
+++ b/cmd/task-server/logics/action/bill/monthtask/aws_outside_bill_month.go
@@ -23,8 +23,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/tidwall/gjson"
-
 	actcli "hcm/cmd/task-server/logics/action/cli"
 	"hcm/pkg/api/core"
 	"hcm/pkg/api/data-service/bill"
@@ -36,6 +34,8 @@ import (
 	"hcm/pkg/kit"
 	"hcm/pkg/logs"
 	cvt "hcm/pkg/tools/converter"
+
+	"github.com/tidwall/gjson"
 )
 
 // AwsOutsideBillMonthTask ...

--- a/pkg/adaptor/types/bill/bill.go
+++ b/pkg/adaptor/types/bill/bill.go
@@ -21,6 +21,7 @@
 package bill
 
 import (
+	"errors"
 	"time"
 
 	"hcm/pkg/adaptor/types/core"
@@ -596,4 +597,21 @@ type AwsSpUsageTotalResult struct {
 	UnblendedCost *decimal.Decimal    `json:"unblended_cost"`
 	SpCost        *decimal.Decimal    `json:"sp_cost"`
 	SpNetCost     *decimal.Decimal    `json:"sp_net_cost"`
+}
+
+// AwsMainOutsideMonthBillLitOpt define aws root outside bill month bill list option.
+type AwsMainOutsideMonthBillLitOpt struct {
+	PayerAccountID  string       `json:"payer_account_id" validate:"required"`
+	UsageAccountIDs []string     `json:"usage_account_ids" validate:"max=20"`
+	Year            uint         `json:"year" validate:"required"`
+	Month           uint         `json:"month" validate:"required,min=1,max=12"`
+	Page            *AwsBillPage `json:"page" validate:"omitempty"`
+}
+
+// Validate ...
+func (opt *AwsMainOutsideMonthBillLitOpt) Validate() error {
+	if opt == nil {
+		return errors.New("opt for get outside month bill is required")
+	}
+	return validator.Validate.Struct(opt)
 }

--- a/pkg/api/hc-service/bill/bill.go
+++ b/pkg/api/hc-service/bill/bill.go
@@ -384,6 +384,24 @@ type AwsRootBillListReq struct {
 	Page    *AwsBillListPage `json:"page" validate:"omitempty"`
 }
 
+// AwsRootOutsideMonthBillListReq defines aws bill record outside given bill month request.
+type AwsRootOutsideMonthBillListReq struct {
+	// 本地根账号
+	RootAccountID string `json:"root_account_id" validate:"required"`
+	// 筛选使用主账号云id，为空则不筛选
+	MainAccountCloudIds []string `json:"main_account_cloud_ids" validate:"max=20,dive,required"`
+
+	BillYear  uint `json:"bill_year" validate:"required"`
+	BillMonth uint `json:"bill_month" validate:"required,min=1,max=12"`
+
+	Page *AwsBillListPage `json:"page" validate:"omitempty"`
+}
+
+// Validate ...
+func (r *AwsRootOutsideMonthBillListReq) Validate() error {
+	return validator.Validate.Struct(r)
+}
+
 // Validate ...
 func (r *AwsRootBillListReq) Validate() error {
 	return validator.Validate.Struct(r)

--- a/pkg/async/consumer/dispatcher.go
+++ b/pkg/async/consumer/dispatcher.go
@@ -86,8 +86,12 @@ func (d *Dispatcher) WatchPendingFlow() {
 // Do 监听处于Pending状态的流，并派发到指定节点。
 func (d *Dispatcher) Do(kt *kit.Kit) error {
 	input := &backend.ListInput{
-		Filter: tools.EqualExpression("state", enumor.FlowPending),
-		Page:   core.NewDefaultBasePage(),
+		Filter: tools.ExpressionAnd(
+			// 走worker,state 索引
+			tools.RuleEqual("worker", ""),
+			tools.RuleEqual("state", enumor.FlowPending),
+		),
+		Page: core.NewDefaultBasePage(),
 	}
 	flows, err := d.bd.ListFlow(kt, input)
 	if err != nil {

--- a/pkg/client/hc-service/aws/bill.go
+++ b/pkg/client/hc-service/aws/bill.go
@@ -129,3 +129,11 @@ func (v *BillClient) GetRootAccountSpTotalUsage(kt *kit.Kit, req *hcbill.AwsRoot
 		v.client, rest.GET, kt, req, "/root_account_bills/sp_usage_total")
 
 }
+
+// ListRootOutsideMonthBill query outside month bill
+func (v *BillClient) ListRootOutsideMonthBill(kt *kit.Kit, req *hcbill.AwsRootOutsideMonthBillListReq) (
+	*core.ListResultT[map[string]string], error) {
+
+	return common.Request[hcbill.AwsRootOutsideMonthBillListReq, core.ListResultT[map[string]string]](
+		v.client, rest.GET, kt, req, "/root_account_bills/list_outside_month_bills")
+}

--- a/pkg/criteria/constant/bill.go
+++ b/pkg/criteria/constant/bill.go
@@ -50,7 +50,8 @@ const GcpCreditReturnConfigKey = "gcp_credit_return_config"
 const AwsLineItemTypeSavingPlanCoveredUsage = "SavingsPlanCoveredUsage"
 
 const (
-
+	// BillOutsideMonthBillName outside bill month bill
+	BillOutsideMonthBillName = "OutsideMonthBill"
 	// BillCommonExpenseReverseName common expense reverse
 	BillCommonExpenseReverseName = "CommonExpenseReverse"
 	// BillCommonExpenseName common expense

--- a/pkg/criteria/enumor/bill.go
+++ b/pkg/criteria/enumor/bill.go
@@ -205,6 +205,8 @@ const (
 type MonthTaskType string
 
 const (
+	// AwsOutsideBillMonthTask usage start date outside current bill month
+	AwsOutsideBillMonthTask MonthTaskType = "outside_month_bill"
 	// AwsSavingsPlansMonthTask aws savings plans month task
 	AwsSavingsPlansMonthTask MonthTaskType = "savings_plans"
 	// AwsSupportMonthTask aws support month task

--- a/scripts/sql/9999_async_table_optimize.sql
+++ b/scripts/sql/9999_async_table_optimize.sql
@@ -1,0 +1,45 @@
+/*
+ * TencentBlueKing is pleased to support the open source community by making
+ * 蓝鲸智云 - 混合云管理平台 (BlueKing - Hybrid Cloud Management System) available.
+ * Copyright (C) 2024 THL A29 Limited,
+ * a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * We undertake not to change the open source license (MIT license) applicable
+ *
+ * to the current version of the project delivered to anyone in the future.
+ */
+
+/*
+    SQLVER=9999,HCMVER=v9.9.9
+
+    Notes:
+    1. 修改`async_flow`表，增加`worker`,`state`索引
+    2. 修改`async_flow`表，增加`state`索引
+    3. 修改`account_bill_item`表，增加(`root_account_id`, `main_account_id`, `bill_day`)索引
+*/
+
+START TRANSACTION;
+
+alter table async_flow
+    add index idx_worker_state_id (worker, state);
+alter table async_flow
+    add index idx_state_id (state, id);
+
+alter table account_bill_item
+    add index `idx_root_main_bill_day` (`root_account_id`, `main_account_id`, `bill_day`);
+
+
+
+CREATE OR REPLACE VIEW `hcm_version`(`hcm_ver`, `sql_ver`) AS
+SELECT 'v9.9.9' as `hcm_ver`, '9999' as `sql_ver`;
+
+COMMIT;
+


### PR DESCRIPTION
增加了`outside_month_bill`类型的monthtask，在sp分账以及support分账之前

--story=119980916 AWS-支持使用日期不在本账单月份的账单