### PR TITLE
fix: 华为云同步报错-validate zone not exist failed, before delete --story=12…

### DIFF
--- a/pkg/adaptor/huawei/zone.go
+++ b/pkg/adaptor/huawei/zone.go
@@ -52,6 +52,7 @@ func (h *HuaWei) ListZone(kt *kit.Kit, opt *typeszone.HuaWeiZoneListOption) ([]t
 	resp, err := client.ListAvailableZones(req)
 	if err != nil {
 		logs.Errorf("list huawei zone failed, err: %v, rid: %s", err, kt.Rid)
+		return nil, err
 	}
 
 	if resp == nil {


### PR DESCRIPTION
…1607417