### PR TITLE
fix: 修复有问题的错误返回

### DIFF
--- a/cmd/task-server/logics/action/load-balancer/batch_task_tcloud_modify_rs_weight.go
+++ b/cmd/task-server/logics/action/load-balancer/batch_task_tcloud_modify_rs_weight.go
@@ -106,7 +106,7 @@ func (act BatchTaskModifyRsWeightAction) Run(kt run.ExecuteKit, params any) (res
 		}
 		if optErr != nil {
 			// abort
-			return nil, err
+			return nil, optErr
 		}
 		results = append(results, ret)
 	}

--- a/cmd/task-server/logics/action/load-balancer/batch_task_tcloud_unbind_targets.go
+++ b/cmd/task-server/logics/action/load-balancer/batch_task_tcloud_unbind_targets.go
@@ -104,7 +104,7 @@ func (act BatchTaskUnBindTargetAction) Run(kt run.ExecuteKit, params any) (resul
 		}
 		if optErr != nil {
 			// abort
-			return nil, err
+			return nil, optErr
 		}
 		results = append(results, ret)
 	}


### PR DESCRIPTION
此处的错误返回值有问题，因为前面已经对 err做了 !=nil && return 的操作，故而此处的err一定为nil。 结合上下文逻辑，应当返回 `optErr`