### PR TITLE
chore: 锁定 less 版本到 4.2.0 修复构建错误

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -82,6 +82,9 @@
     "stylelint-config-standard-vue": "1.0.0",
     "typescript": "4.7.4"
   },
+  "overrides": {
+    "less": "4.2.0"
+  },
   "engines": {
     "node": ">= v16.20.2",
     "npm": "^8.19.4"


### PR DESCRIPTION
less 4.6.x 迁移至 ESM 格式导致 less-loader 调用 logger.addListener 失败， 通过 npm overrides 将 less 锁定在 4.2.0 (CommonJS) 修复该问题。