### PR TITLE
feat: add aws sagemaker hyperparameter tuning job APIs --story=133541921

### DIFF
--- a/cmd/cloud-server/service/sagemaker/aws.go
+++ b/cmd/cloud-server/service/sagemaker/aws.go
@@ -210,6 +210,52 @@ func (svc *service) GetTrainingJobInRes(cts *rest.Contexts) (interface{}, error)
 	return data, nil
 }
 
+// ListHyperParameterTuningJobsInRes handles the cloud-server SageMaker assume-role passthrough request.
+func (svc *service) ListHyperParameterTuningJobsInRes(cts *rest.Contexts) (interface{}, error) {
+	req := new(proto.AwsAssumeRoleSageMakerListHyperParameterTuningJobsReq)
+	if err := cts.DecodeInto(req); err != nil {
+		return nil, errf.NewFromErr(errf.DecodeRequestFailed, err)
+	}
+	if err := req.Validate(); err != nil {
+		return nil, errf.NewFromErr(errf.InvalidParameter, err)
+	}
+	if err := svc.authRootAccount(cts, req.RootAccountID); err != nil {
+		return nil, err
+	}
+	data, err := svc.client.HCService().Aws.SageMaker.ListHyperParameterTuningJobs(cts.Kit, req)
+	if err != nil {
+		logs.Errorf(
+			"call hc-service to list aws assume role sagemaker hyperparameter tuning jobs failed, err: %v, rid: %s",
+			err, cts.Kit.Rid,
+		)
+		return nil, err
+	}
+	return data, nil
+}
+
+// GetHyperParameterTuningJobInRes handles the cloud-server SageMaker assume-role passthrough request.
+func (svc *service) GetHyperParameterTuningJobInRes(cts *rest.Contexts) (interface{}, error) {
+	req := new(proto.AwsAssumeRoleSageMakerDescribeHyperParameterTuningJobReq)
+	if err := cts.DecodeInto(req); err != nil {
+		return nil, errf.NewFromErr(errf.DecodeRequestFailed, err)
+	}
+	if err := req.Validate(); err != nil {
+		return nil, errf.NewFromErr(errf.InvalidParameter, err)
+	}
+	if err := svc.authRootAccount(cts, req.RootAccountID); err != nil {
+		return nil, err
+	}
+	data, err := svc.client.HCService().Aws.SageMaker.GetHyperParameterTuningJob(cts.Kit, req)
+	if err != nil {
+		logs.Errorf(
+			"call hc-service to describe aws assume role sagemaker hyperparameter tuning job failed, err: %v, rid: %s",
+			err, cts.Kit.Rid,
+		)
+		return nil, err
+	}
+	return data, nil
+}
+
 // ListProcessingJobsInRes handles the cloud-server SageMaker assume-role passthrough request.
 func (svc *service) ListProcessingJobsInRes(cts *rest.Contexts) (interface{}, error) {
 	req := new(proto.AwsAssumeRoleSageMakerListProcessingJobsReq)

--- a/cmd/cloud-server/service/sagemaker/init.go
+++ b/cmd/cloud-server/service/sagemaker/init.go
@@ -57,6 +57,10 @@ func InitService(c *capability.Capability) {
 		"/vendors/aws/assume_role/sagemaker/training_jobs/list", svc.ListTrainingJobsInRes)
 	h.Add("GetTrainingJobInRes", http.MethodPost,
 		"/vendors/aws/assume_role/sagemaker/training_jobs/get", svc.GetTrainingJobInRes)
+	h.Add("ListHyperParameterTuningJobsInRes", http.MethodPost,
+		"/vendors/aws/assume_role/sagemaker/hyper_parameter_tuning_jobs/list", svc.ListHyperParameterTuningJobsInRes)
+	h.Add("GetHyperParameterTuningJobInRes", http.MethodPost,
+		"/vendors/aws/assume_role/sagemaker/hyper_parameter_tuning_jobs/get", svc.GetHyperParameterTuningJobInRes)
 	h.Add("ListProcessingJobsInRes", http.MethodPost,
 		"/vendors/aws/assume_role/sagemaker/processing_jobs/list", svc.ListProcessingJobsInRes)
 	h.Add("GetProcessingJobInRes", http.MethodPost,

--- a/cmd/hc-service/service/sagemaker/aws.go
+++ b/cmd/hc-service/service/sagemaker/aws.go
@@ -256,6 +256,66 @@ func (s *sageMakerSvc) GetTrainingJobForAws(cts *rest.Contexts) (interface{}, er
 	return result, nil
 }
 
+// ListHyperParameterTuningJobsForAws handles the hc-service SageMaker assume-role passthrough request.
+func (s *sageMakerSvc) ListHyperParameterTuningJobsForAws(cts *rest.Contexts) (interface{}, error) {
+	req := new(proto.AwsAssumeRoleSageMakerListHyperParameterTuningJobsReq)
+	if err := cts.DecodeInto(req); err != nil {
+		return nil, errf.NewFromErr(errf.DecodeRequestFailed, err)
+	}
+	if err := req.Validate(); err != nil {
+		return nil, errf.NewFromErr(errf.InvalidParameter, err)
+	}
+	client, err := s.assumeRoleClient(cts.Kit, req)
+	if err != nil {
+		return nil, err
+	}
+	result, err := client.ListHyperParameterTuningJobs(cts.Kit, &adaptorsm.AwsListHyperParameterTuningJobsOption{
+		Region:                 req.Region,
+		CreationTimeAfter:      req.CreationTimeAfter,
+		CreationTimeBefore:     req.CreationTimeBefore,
+		LastModifiedTimeAfter:  req.LastModifiedTimeAfter,
+		LastModifiedTimeBefore: req.LastModifiedTimeBefore,
+		MaxResults:             req.MaxResults,
+		NameContains:           req.NameContains,
+		NextToken:              converter.StrNilPtr(req.NextToken),
+		SortBy:                 req.SortBy,
+		SortOrder:              req.SortOrder,
+		StatusEquals:           req.StatusEquals,
+	})
+	if err != nil {
+		logs.Errorf("list aws assume role sagemaker hyperparameter tuning jobs failed, err: %v, rid: %s",
+			err, cts.Kit.Rid)
+		return nil, err
+	}
+	return result, nil
+}
+
+// GetHyperParameterTuningJobForAws handles the hc-service SageMaker assume-role passthrough request.
+func (s *sageMakerSvc) GetHyperParameterTuningJobForAws(cts *rest.Contexts) (interface{}, error) {
+	req := new(proto.AwsAssumeRoleSageMakerDescribeHyperParameterTuningJobReq)
+	if err := cts.DecodeInto(req); err != nil {
+		return nil, errf.NewFromErr(errf.DecodeRequestFailed, err)
+	}
+	if err := req.Validate(); err != nil {
+		return nil, errf.NewFromErr(errf.InvalidParameter, err)
+	}
+	client, err := s.assumeRoleClient(cts.Kit, req)
+	if err != nil {
+		return nil, err
+	}
+	result, err := client.DescribeHyperParameterTuningJob(cts.Kit,
+		&adaptorsm.AwsDescribeHyperParameterTuningJobOption{
+			Region:                      req.Region,
+			HyperParameterTuningJobName: req.HyperParameterTuningJobName,
+		})
+	if err != nil {
+		logs.Errorf("describe aws assume role sagemaker hyperparameter tuning job failed, err: %v, rid: %s",
+			err, cts.Kit.Rid)
+		return nil, err
+	}
+	return result, nil
+}
+
 // ListProcessingJobsForAws handles the hc-service SageMaker assume-role passthrough request.
 func (s *sageMakerSvc) ListProcessingJobsForAws(cts *rest.Contexts) (interface{}, error) {
 	req := new(proto.AwsAssumeRoleSageMakerListProcessingJobsReq)

--- a/cmd/hc-service/service/sagemaker/service.go
+++ b/cmd/hc-service/service/sagemaker/service.go
@@ -68,6 +68,10 @@ func InitService(cap *capability.Capability) {
 		"/vendors/aws/assume_role/sagemaker/training_jobs/list", svc.ListTrainingJobsForAws)
 	h.Add("GetTrainingJobForAws", "POST",
 		"/vendors/aws/assume_role/sagemaker/training_jobs/get", svc.GetTrainingJobForAws)
+	h.Add("ListHyperParameterTuningJobsForAws", "POST",
+		"/vendors/aws/assume_role/sagemaker/hyper_parameter_tuning_jobs/list", svc.ListHyperParameterTuningJobsForAws)
+	h.Add("GetHyperParameterTuningJobForAws", "POST",
+		"/vendors/aws/assume_role/sagemaker/hyper_parameter_tuning_jobs/get", svc.GetHyperParameterTuningJobForAws)
 	h.Add("ListProcessingJobsForAws", "POST",
 		"/vendors/aws/assume_role/sagemaker/processing_jobs/list", svc.ListProcessingJobsForAws)
 	h.Add("GetProcessingJobForAws", "POST",

--- a/docs/api-docs/api-server/api/bk_apigw_resources_bk-hcm.yaml
+++ b/docs/api-docs/api-server/api/bk_apigw_resources_bk-hcm.yaml
@@ -368,8 +368,8 @@ paths:
         default:
           description: ''
       x-bk-apigateway-resource:
-        isPublic: true
-        allowApplyPermission: true
+        isPublic: false
+        allowApplyPermission: false
         matchSubpath: false
         backend:
           type: HTTP
@@ -380,7 +380,7 @@ paths:
           upstreams: {}
           transformHeaders: {}
         authConfig:
-          userVerifiedRequired: true
+          userVerifiedRequired: false
         disabledStages: []
         descriptionEn: List AWS member account SageMaker notebook instances via AssumeRole
   /api/v1/cloud/vendors/aws/assume_role/sagemaker/notebook_instances/get:
@@ -394,8 +394,8 @@ paths:
         default:
           description: ''
       x-bk-apigateway-resource:
-        isPublic: true
-        allowApplyPermission: true
+        isPublic: false
+        allowApplyPermission: false
         matchSubpath: false
         backend:
           type: HTTP
@@ -406,7 +406,7 @@ paths:
           upstreams: {}
           transformHeaders: {}
         authConfig:
-          userVerifiedRequired: true
+          userVerifiedRequired: false
         disabledStages: []
         descriptionEn: Get AWS member account SageMaker notebook instance via AssumeRole
   /api/v1/cloud/vendors/aws/assume_role/sagemaker/endpoints/list:
@@ -420,8 +420,8 @@ paths:
         default:
           description: ''
       x-bk-apigateway-resource:
-        isPublic: true
-        allowApplyPermission: true
+        isPublic: false
+        allowApplyPermission: false
         matchSubpath: false
         backend:
           type: HTTP
@@ -432,7 +432,7 @@ paths:
           upstreams: {}
           transformHeaders: {}
         authConfig:
-          userVerifiedRequired: true
+          userVerifiedRequired: false
         disabledStages: []
         descriptionEn: List AWS member account SageMaker endpoints via AssumeRole
   /api/v1/cloud/vendors/aws/assume_role/sagemaker/endpoints/get:
@@ -446,8 +446,8 @@ paths:
         default:
           description: ''
       x-bk-apigateway-resource:
-        isPublic: true
-        allowApplyPermission: true
+        isPublic: false
+        allowApplyPermission: false
         matchSubpath: false
         backend:
           type: HTTP
@@ -458,7 +458,7 @@ paths:
           upstreams: {}
           transformHeaders: {}
         authConfig:
-          userVerifiedRequired: true
+          userVerifiedRequired: false
         disabledStages: []
         descriptionEn: Get AWS member account SageMaker endpoint via AssumeRole
   /api/v1/cloud/vendors/aws/assume_role/sagemaker/endpoint_configs/list:
@@ -472,8 +472,8 @@ paths:
         default:
           description: ''
       x-bk-apigateway-resource:
-        isPublic: true
-        allowApplyPermission: true
+        isPublic: false
+        allowApplyPermission: false
         matchSubpath: false
         backend:
           type: HTTP
@@ -484,7 +484,7 @@ paths:
           upstreams: {}
           transformHeaders: {}
         authConfig:
-          userVerifiedRequired: true
+          userVerifiedRequired: false
         disabledStages: []
         descriptionEn: List AWS member account SageMaker endpoint configs via AssumeRole
   /api/v1/cloud/vendors/aws/assume_role/sagemaker/endpoint_configs/get:
@@ -498,8 +498,8 @@ paths:
         default:
           description: ''
       x-bk-apigateway-resource:
-        isPublic: true
-        allowApplyPermission: true
+        isPublic: false
+        allowApplyPermission: false
         matchSubpath: false
         backend:
           type: HTTP
@@ -510,7 +510,7 @@ paths:
           upstreams: {}
           transformHeaders: {}
         authConfig:
-          userVerifiedRequired: true
+          userVerifiedRequired: false
         disabledStages: []
         descriptionEn: Get AWS member account SageMaker endpoint config via AssumeRole
   /api/v1/cloud/vendors/aws/assume_role/sagemaker/training_jobs/list:
@@ -524,8 +524,8 @@ paths:
         default:
           description: ''
       x-bk-apigateway-resource:
-        isPublic: true
-        allowApplyPermission: true
+        isPublic: false
+        allowApplyPermission: false
         matchSubpath: false
         backend:
           type: HTTP
@@ -536,7 +536,7 @@ paths:
           upstreams: {}
           transformHeaders: {}
         authConfig:
-          userVerifiedRequired: true
+          userVerifiedRequired: false
         disabledStages: []
         descriptionEn: List AWS member account SageMaker training jobs via AssumeRole
   /api/v1/cloud/vendors/aws/assume_role/sagemaker/training_jobs/get:
@@ -550,8 +550,8 @@ paths:
         default:
           description: ''
       x-bk-apigateway-resource:
-        isPublic: true
-        allowApplyPermission: true
+        isPublic: false
+        allowApplyPermission: false
         matchSubpath: false
         backend:
           type: HTTP
@@ -562,9 +562,61 @@ paths:
           upstreams: {}
           transformHeaders: {}
         authConfig:
-          userVerifiedRequired: true
+          userVerifiedRequired: false
         disabledStages: []
         descriptionEn: Get AWS member account SageMaker training job via AssumeRole
+  /api/v1/cloud/vendors/aws/assume_role/sagemaker/hyper_parameter_tuning_jobs/list:
+    post:
+      operationId: list_aws_assume_role_sagemaker_hyper_parameter_tuning_jobs
+      description: 查询 AWS 成员账号 SageMaker HyperParameterTuningJob 列表（通过 AssumeRole 跨账号访问）
+      tags:
+        - SageMaker
+        - Aws
+      responses:
+        default:
+          description: ''
+      x-bk-apigateway-resource:
+        isPublic: false
+        allowApplyPermission: false
+        matchSubpath: false
+        backend:
+          type: HTTP
+          method: post
+          path: /api/v1/cloud/vendors/aws/assume_role/sagemaker/hyper_parameter_tuning_jobs/list
+          matchSubpath: false
+          timeout: 60
+          upstreams: {}
+          transformHeaders: {}
+        authConfig:
+          userVerifiedRequired: false
+        disabledStages: []
+        descriptionEn: List AWS member account SageMaker hyperparameter tuning jobs via AssumeRole
+  /api/v1/cloud/vendors/aws/assume_role/sagemaker/hyper_parameter_tuning_jobs/get:
+    post:
+      operationId: get_aws_assume_role_sagemaker_hyper_parameter_tuning_job
+      description: 查询 AWS 成员账号 SageMaker HyperParameterTuningJob 详情（通过 AssumeRole 跨账号访问）
+      tags:
+        - SageMaker
+        - Aws
+      responses:
+        default:
+          description: ''
+      x-bk-apigateway-resource:
+        isPublic: false
+        allowApplyPermission: false
+        matchSubpath: false
+        backend:
+          type: HTTP
+          method: post
+          path: /api/v1/cloud/vendors/aws/assume_role/sagemaker/hyper_parameter_tuning_jobs/get
+          matchSubpath: false
+          timeout: 60
+          upstreams: {}
+          transformHeaders: {}
+        authConfig:
+          userVerifiedRequired: false
+        disabledStages: []
+        descriptionEn: Get AWS member account SageMaker hyperparameter tuning job via AssumeRole
   /api/v1/cloud/vendors/aws/assume_role/sagemaker/processing_jobs/list:
     post:
       operationId: list_aws_assume_role_sagemaker_processing_jobs
@@ -576,8 +628,8 @@ paths:
         default:
           description: ''
       x-bk-apigateway-resource:
-        isPublic: true
-        allowApplyPermission: true
+        isPublic: false
+        allowApplyPermission: false
         matchSubpath: false
         backend:
           type: HTTP
@@ -588,7 +640,7 @@ paths:
           upstreams: {}
           transformHeaders: {}
         authConfig:
-          userVerifiedRequired: true
+          userVerifiedRequired: false
         disabledStages: []
         descriptionEn: List AWS member account SageMaker processing jobs via AssumeRole
   /api/v1/cloud/vendors/aws/assume_role/sagemaker/processing_jobs/get:
@@ -602,8 +654,8 @@ paths:
         default:
           description: ''
       x-bk-apigateway-resource:
-        isPublic: true
-        allowApplyPermission: true
+        isPublic: false
+        allowApplyPermission: false
         matchSubpath: false
         backend:
           type: HTTP
@@ -614,7 +666,7 @@ paths:
           upstreams: {}
           transformHeaders: {}
         authConfig:
-          userVerifiedRequired: true
+          userVerifiedRequired: false
         disabledStages: []
         descriptionEn: Get AWS member account SageMaker processing job via AssumeRole
   /api/v1/cloud/vendors/aws/assume_role/sagemaker/transform_jobs/list:
@@ -628,8 +680,8 @@ paths:
         default:
           description: ''
       x-bk-apigateway-resource:
-        isPublic: true
-        allowApplyPermission: true
+        isPublic: false
+        allowApplyPermission: false
         matchSubpath: false
         backend:
           type: HTTP
@@ -640,7 +692,7 @@ paths:
           upstreams: {}
           transformHeaders: {}
         authConfig:
-          userVerifiedRequired: true
+          userVerifiedRequired: false
         disabledStages: []
         descriptionEn: List AWS member account SageMaker transform jobs via AssumeRole
   /api/v1/cloud/vendors/aws/assume_role/sagemaker/transform_jobs/get:
@@ -654,8 +706,8 @@ paths:
         default:
           description: ''
       x-bk-apigateway-resource:
-        isPublic: true
-        allowApplyPermission: true
+        isPublic: false
+        allowApplyPermission: false
         matchSubpath: false
         backend:
           type: HTTP
@@ -666,7 +718,7 @@ paths:
           upstreams: {}
           transformHeaders: {}
         authConfig:
-          userVerifiedRequired: true
+          userVerifiedRequired: false
         disabledStages: []
         descriptionEn: Get AWS member account SageMaker transform job via AssumeRole
   /api/v1/cloud/vendors/aws/assume_role/sagemaker/apps/list:
@@ -680,8 +732,8 @@ paths:
         default:
           description: ''
       x-bk-apigateway-resource:
-        isPublic: true
-        allowApplyPermission: true
+        isPublic: false
+        allowApplyPermission: false
         matchSubpath: false
         backend:
           type: HTTP
@@ -692,7 +744,7 @@ paths:
           upstreams: {}
           transformHeaders: {}
         authConfig:
-          userVerifiedRequired: true
+          userVerifiedRequired: false
         disabledStages: []
         descriptionEn: List AWS member account SageMaker Studio apps via AssumeRole
   /api/v1/cloud/vendors/aws/assume_role/sagemaker/apps/get:
@@ -706,8 +758,8 @@ paths:
         default:
           description: ''
       x-bk-apigateway-resource:
-        isPublic: true
-        allowApplyPermission: true
+        isPublic: false
+        allowApplyPermission: false
         matchSubpath: false
         backend:
           type: HTTP
@@ -718,7 +770,7 @@ paths:
           upstreams: {}
           transformHeaders: {}
         authConfig:
-          userVerifiedRequired: true
+          userVerifiedRequired: false
         disabledStages: []
         descriptionEn: Get AWS member account SageMaker Studio app via AssumeRole
   /api/v1/cloud/vendors/aws/assume_role/sagemaker/clusters/list:
@@ -732,8 +784,8 @@ paths:
         default:
           description: ''
       x-bk-apigateway-resource:
-        isPublic: true
-        allowApplyPermission: true
+        isPublic: false
+        allowApplyPermission: false
         matchSubpath: false
         backend:
           type: HTTP
@@ -744,7 +796,7 @@ paths:
           upstreams: {}
           transformHeaders: {}
         authConfig:
-          userVerifiedRequired: true
+          userVerifiedRequired: false
         disabledStages: []
         descriptionEn: List AWS member account SageMaker HyperPod clusters via AssumeRole
   /api/v1/cloud/vendors/aws/assume_role/sagemaker/clusters/get:
@@ -758,8 +810,8 @@ paths:
         default:
           description: ''
       x-bk-apigateway-resource:
-        isPublic: true
-        allowApplyPermission: true
+        isPublic: false
+        allowApplyPermission: false
         matchSubpath: false
         backend:
           type: HTTP
@@ -770,7 +822,7 @@ paths:
           upstreams: {}
           transformHeaders: {}
         authConfig:
-          userVerifiedRequired: true
+          userVerifiedRequired: false
         disabledStages: []
         descriptionEn: Get AWS member account SageMaker HyperPod cluster via AssumeRole
   /api/v1/cloud/vendors/aws/assume_role/sagemaker/cluster_nodes/list:
@@ -784,8 +836,8 @@ paths:
         default:
           description: ''
       x-bk-apigateway-resource:
-        isPublic: true
-        allowApplyPermission: true
+        isPublic: false
+        allowApplyPermission: false
         matchSubpath: false
         backend:
           type: HTTP
@@ -796,7 +848,7 @@ paths:
           upstreams: {}
           transformHeaders: {}
         authConfig:
-          userVerifiedRequired: true
+          userVerifiedRequired: false
         disabledStages: []
         descriptionEn: List AWS member account SageMaker HyperPod cluster nodes via AssumeRole
   /api/v1/cloud/vendors/aws/assume_role/sagemaker/cluster_nodes/get:
@@ -810,8 +862,8 @@ paths:
         default:
           description: ''
       x-bk-apigateway-resource:
-        isPublic: true
-        allowApplyPermission: true
+        isPublic: false
+        allowApplyPermission: false
         matchSubpath: false
         backend:
           type: HTTP
@@ -822,7 +874,7 @@ paths:
           upstreams: {}
           transformHeaders: {}
         authConfig:
-          userVerifiedRequired: true
+          userVerifiedRequired: false
         disabledStages: []
         descriptionEn: Get AWS member account SageMaker HyperPod cluster node via AssumeRole
   /api/v1/cloud/vendors/aws/assume_role/sagemaker/training_plans/list:
@@ -836,8 +888,8 @@ paths:
         default:
           description: ''
       x-bk-apigateway-resource:
-        isPublic: true
-        allowApplyPermission: true
+        isPublic: false
+        allowApplyPermission: false
         matchSubpath: false
         backend:
           type: HTTP
@@ -848,7 +900,7 @@ paths:
           upstreams: {}
           transformHeaders: {}
         authConfig:
-          userVerifiedRequired: true
+          userVerifiedRequired: false
         disabledStages: []
         descriptionEn: List AWS member account SageMaker training plans via AssumeRole
   /api/v1/cloud/vendors/aws/assume_role/sagemaker/training_plans/get:
@@ -862,8 +914,8 @@ paths:
         default:
           description: ''
       x-bk-apigateway-resource:
-        isPublic: true
-        allowApplyPermission: true
+        isPublic: false
+        allowApplyPermission: false
         matchSubpath: false
         backend:
           type: HTTP
@@ -874,7 +926,7 @@ paths:
           upstreams: {}
           transformHeaders: {}
         authConfig:
-          userVerifiedRequired: true
+          userVerifiedRequired: false
         disabledStages: []
         descriptionEn: Get AWS member account SageMaker training plan via AssumeRole
   /api/v1/cloud/vendors/aws/assume_role/sagemaker/training_plan_offerings/search:
@@ -888,8 +940,8 @@ paths:
         default:
           description: ''
       x-bk-apigateway-resource:
-        isPublic: true
-        allowApplyPermission: true
+        isPublic: false
+        allowApplyPermission: false
         matchSubpath: false
         backend:
           type: HTTP
@@ -900,7 +952,7 @@ paths:
           upstreams: {}
           transformHeaders: {}
         authConfig:
-          userVerifiedRequired: true
+          userVerifiedRequired: false
         disabledStages: []
         descriptionEn: Search AWS member account SageMaker training plan offerings via AssumeRole
   /api/v1/cloud/vendors/aws/assume_role/sagemaker/inference_components/list:
@@ -914,8 +966,8 @@ paths:
         default:
           description: ''
       x-bk-apigateway-resource:
-        isPublic: true
-        allowApplyPermission: true
+        isPublic: false
+        allowApplyPermission: false
         matchSubpath: false
         backend:
           type: HTTP
@@ -926,7 +978,7 @@ paths:
           upstreams: {}
           transformHeaders: {}
         authConfig:
-          userVerifiedRequired: true
+          userVerifiedRequired: false
         disabledStages: []
         descriptionEn: List AWS member account SageMaker inference components via AssumeRole
   /api/v1/cloud/vendors/aws/assume_role/sagemaker/inference_components/get:
@@ -940,8 +992,8 @@ paths:
         default:
           description: ''
       x-bk-apigateway-resource:
-        isPublic: true
-        allowApplyPermission: true
+        isPublic: false
+        allowApplyPermission: false
         matchSubpath: false
         backend:
           type: HTTP
@@ -952,7 +1004,7 @@ paths:
           upstreams: {}
           transformHeaders: {}
         authConfig:
-          userVerifiedRequired: true
+          userVerifiedRequired: false
         disabledStages: []
         descriptionEn: Get AWS member account SageMaker inference component via AssumeRole
   /api/v1/cloud/vendors/aws/assume_role/sagemaker/optimization_jobs/list:
@@ -966,8 +1018,8 @@ paths:
         default:
           description: ''
       x-bk-apigateway-resource:
-        isPublic: true
-        allowApplyPermission: true
+        isPublic: false
+        allowApplyPermission: false
         matchSubpath: false
         backend:
           type: HTTP
@@ -978,7 +1030,7 @@ paths:
           upstreams: {}
           transformHeaders: {}
         authConfig:
-          userVerifiedRequired: true
+          userVerifiedRequired: false
         disabledStages: []
         descriptionEn: List AWS member account SageMaker optimization jobs via AssumeRole
   /api/v1/cloud/vendors/aws/assume_role/sagemaker/optimization_jobs/get:
@@ -992,8 +1044,8 @@ paths:
         default:
           description: ''
       x-bk-apigateway-resource:
-        isPublic: true
-        allowApplyPermission: true
+        isPublic: false
+        allowApplyPermission: false
         matchSubpath: false
         backend:
           type: HTTP
@@ -1004,7 +1056,7 @@ paths:
           upstreams: {}
           transformHeaders: {}
         authConfig:
-          userVerifiedRequired: true
+          userVerifiedRequired: false
         disabledStages: []
         descriptionEn: Get AWS member account SageMaker optimization job via AssumeRole
   /api/v1/cloud/vendors/aws/assume_role/sagemaker/compute_quotas/list:
@@ -1018,8 +1070,8 @@ paths:
         default:
           description: ''
       x-bk-apigateway-resource:
-        isPublic: true
-        allowApplyPermission: true
+        isPublic: false
+        allowApplyPermission: false
         matchSubpath: false
         backend:
           type: HTTP
@@ -1030,7 +1082,7 @@ paths:
           upstreams: {}
           transformHeaders: {}
         authConfig:
-          userVerifiedRequired: true
+          userVerifiedRequired: false
         disabledStages: []
         descriptionEn: List AWS member account SageMaker compute quotas via AssumeRole
   /api/v1/cloud/vendors/aws/assume_role/sagemaker/compute_quotas/get:
@@ -1044,8 +1096,8 @@ paths:
         default:
           description: ''
       x-bk-apigateway-resource:
-        isPublic: true
-        allowApplyPermission: true
+        isPublic: false
+        allowApplyPermission: false
         matchSubpath: false
         backend:
           type: HTTP
@@ -1056,7 +1108,7 @@ paths:
           upstreams: {}
           transformHeaders: {}
         authConfig:
-          userVerifiedRequired: true
+          userVerifiedRequired: false
         disabledStages: []
         descriptionEn: Get AWS member account SageMaker compute quota via AssumeRole
   /api/v1/cloud/vendors/aws/assume_role/sagemaker/reserved_capacities/get:
@@ -1070,8 +1122,8 @@ paths:
         default:
           description: ''
       x-bk-apigateway-resource:
-        isPublic: true
-        allowApplyPermission: true
+        isPublic: false
+        allowApplyPermission: false
         matchSubpath: false
         backend:
           type: HTTP
@@ -1082,7 +1134,7 @@ paths:
           upstreams: {}
           transformHeaders: {}
         authConfig:
-          userVerifiedRequired: true
+          userVerifiedRequired: false
         disabledStages: []
         descriptionEn: Get AWS member account SageMaker reserved capacity via AssumeRole
   /api/v1/cloud/vendors/aws/assume_role/sagemaker/reserved_capacity_ultra_servers/list:
@@ -1096,8 +1148,8 @@ paths:
         default:
           description: ''
       x-bk-apigateway-resource:
-        isPublic: true
-        allowApplyPermission: true
+        isPublic: false
+        allowApplyPermission: false
         matchSubpath: false
         backend:
           type: HTTP
@@ -1108,7 +1160,7 @@ paths:
           upstreams: {}
           transformHeaders: {}
         authConfig:
-          userVerifiedRequired: true
+          userVerifiedRequired: false
         disabledStages: []
         descriptionEn: List AWS member account SageMaker reserved capacity UltraServers via AssumeRole
   /api/v1/account/main_accounts/list:
@@ -1136,4 +1188,3 @@ paths:
           userVerifiedRequired: false
         disabledStages: []
         descriptionEn: List main accounts
-

--- a/docs/api-docs/web-server/docs/resource/get_aws_assume_role_sagemaker_hyper_parameter_tuning_job.md
+++ b/docs/api-docs/web-server/docs/resource/get_aws_assume_role_sagemaker_hyper_parameter_tuning_job.md
@@ -1,0 +1,74 @@
+### 描述
+
+- 该接口提供版本：9.9.9。
+- 该接口所需权限：资源查看。
+- 该接口功能描述：查询 AWS 成员账号指定 SageMaker HyperParameterTuningJob 的详情。通过 STS AssumeRole 跨账号访问成员账号的 SageMaker 原生详情接口，透传返回 AWS 原始响应。
+
+### URL
+
+POST /api/v1/cloud/vendors/aws/assume_role/sagemaker/hyper_parameter_tuning_jobs/get
+
+### 请求参数
+
+| 参数名称           | 参数类型     | 必选 | 描述 |
+|----------------|----------|----|------|
+| root_account_id | string   | 是  | 根账号 ID，用于获取 AWS 根账号凭证 |
+| main_account_id | string   | 是  | 主账号 ID，用于查询 main_account 表获取成员账号的 AWS Account ID |
+| role_chain     | string[] | 是  | 角色名数组，支持 Role Chaining。中间角色在管理账号中 AssumeRole，最后一个角色在成员账号中 AssumeRole。至少包含 1 个角色名 |
+| region         | string   | 是  | AWS 区域，如 us-east-1 |
+| external_id    | string   | 否  | STS AssumeRole 的 ExternalId，用于目标角色 Trust Policy 的条件验证。仅应用于 Role Chain 最后一步 |
+| hyper_parameter_tuning_job_name | string | 是 | HyperParameterTuningJob 名称 |
+
+
+### 调用示例
+
+#### 请求参数示例
+
+```json
+{
+  "root_account_id": "00000001",
+  "main_account_id": "00000002",
+  "role_chain": ["SageMakerReadOnlyRole"],
+  "region": "us-east-1",
+  "hyper_parameter_tuning_job_name": "demo-tuning-job"
+}
+```
+
+#### 返回参数示例
+
+> **注意**：`data` 为 AWS SageMaker 原始响应结构透传，完整字段请参考 AWS SageMaker 对应 API 文档，以下仅展示常用字段。
+
+```json
+{
+  "code": 0,
+  "message": "",
+  "data": {
+    "HyperParameterTuningJobName": "demo-tuning-job",
+    "HyperParameterTuningJobStatus": "Completed",
+    "BestTrainingJob": {
+      "TrainingJobName": "demo-training-job-001",
+      "TrainingJobStatus": "Completed",
+      "FinalHyperParameterTuningJobObjectiveMetric": {
+        "MetricName": "validation:accuracy",
+        "Value": 0.97
+      }
+    },
+    "TrainingJobStatusCounters": {
+      "Completed": 12,
+      "InProgress": 0
+    }
+  }
+}
+```
+
+### 响应参数说明
+
+| 参数名称 | 参数类型 | 描述 |
+|--------|--------|------|
+| code | int | 状态码 |
+| message | string | 请求信息 |
+| data | object | AWS SageMaker `DescribeHyperParameterTuningJob` 原始响应透传 |
+| data.HyperParameterTuningJobName | string | HyperParameterTuningJob 名称 |
+| data.HyperParameterTuningJobStatus | string | HyperParameterTuningJob 状态 |
+| data.BestTrainingJob | object | 当前最佳训练任务信息 |
+| data.TrainingJobStatusCounters | object | 调参任务发起的训练任务状态统计 |

--- a/docs/api-docs/web-server/docs/resource/list_aws_assume_role_sagemaker_hyper_parameter_tuning_jobs.md
+++ b/docs/api-docs/web-server/docs/resource/list_aws_assume_role_sagemaker_hyper_parameter_tuning_jobs.md
@@ -1,0 +1,75 @@
+### 描述
+
+- 该接口提供版本：9.9.9。
+- 该接口所需权限：资源查看。
+- 该接口功能描述：查询 AWS 成员账号的 SageMaker HyperParameterTuningJob 列表。通过 STS AssumeRole 跨账号访问成员账号的 SageMaker 原生列表接口，透传返回 AWS 原始响应。
+
+### URL
+
+POST /api/v1/cloud/vendors/aws/assume_role/sagemaker/hyper_parameter_tuning_jobs/list
+
+### 请求参数
+
+| 参数名称           | 参数类型     | 必选 | 描述 |
+|----------------|----------|----|------|
+| root_account_id | string   | 是  | 根账号 ID，用于获取 AWS 根账号凭证 |
+| main_account_id | string   | 是  | 主账号 ID，用于查询 main_account 表获取成员账号的 AWS Account ID |
+| role_chain     | string[] | 是  | 角色名数组，支持 Role Chaining。中间角色在管理账号中 AssumeRole，最后一个角色在成员账号中 AssumeRole。至少包含 1 个角色名 |
+| region         | string   | 是  | AWS 区域，如 us-east-1 |
+| external_id    | string   | 否  | STS AssumeRole 的 ExternalId，用于目标角色 Trust Policy 的条件验证。仅应用于 Role Chain 最后一步 |
+| creation_time_after | string | 否 | 创建时间下界，RFC3339 时间格式 |
+| creation_time_before | string | 否 | 创建时间上界，RFC3339 时间格式 |
+| last_modified_time_after | string | 否 | 最后修改时间下界，RFC3339 时间格式 |
+| last_modified_time_before | string | 否 | 最后修改时间上界，RFC3339 时间格式 |
+| max_results | int32 | 否 | 分页大小，最小值 1 |
+| name_contains | string | 否 | HyperParameterTuningJob 名称模糊匹配 |
+| next_token | string | 否 | AWS 分页 token |
+| sort_by | string | 否 | AWS 原生排序字段 |
+| sort_order | string | 否 | AWS 原生排序方向 |
+| status_equals | string | 否 | AWS 原生状态过滤 |
+
+
+### 调用示例
+
+#### 请求参数示例
+
+```json
+{
+  "root_account_id": "00000001",
+  "main_account_id": "00000002",
+  "role_chain": ["SageMakerReadOnlyRole"],
+  "region": "us-east-1",
+  "status_equals": "Completed"
+}
+```
+
+#### 返回参数示例
+
+> **注意**：`data` 为 AWS SageMaker 原始响应结构透传，完整字段请参考 AWS SageMaker 对应 API 文档，以下仅展示常用字段。
+
+```json
+{
+  "code": 0,
+  "message": "",
+  "data": {
+    "HyperParameterTuningJobSummaries": [
+      {
+        "HyperParameterTuningJobName": "demo-tuning-job",
+        "HyperParameterTuningJobArn": "arn:aws:sagemaker:us-east-1:123456789012:hyper-parameter-tuning-job/demo-tuning-job",
+        "HyperParameterTuningJobStatus": "Completed",
+        "CreationTime": "2026-04-01T08:00:00Z"
+      }
+    ]
+  }
+}
+```
+
+### 响应参数说明
+
+| 参数名称 | 参数类型 | 描述 |
+|--------|--------|------|
+| code | int | 状态码 |
+| message | string | 请求信息 |
+| data | object | AWS SageMaker `ListHyperParameterTuningJobs` 原始响应透传，通常包含 `HyperParameterTuningJobSummaries` 和可选 `NextToken` |
+| data.HyperParameterTuningJobSummaries | array | HyperParameterTuningJob 列表 |
+| data.NextToken | string | AWS 分页 token，存在时表示还有下一页 |

--- a/pkg/adaptor/aws/sagemaker.go
+++ b/pkg/adaptor/aws/sagemaker.go
@@ -262,6 +262,63 @@ func (a *Aws) DescribeTrainingJob(kt *kit.Kit,
 	return resp, nil
 }
 
+// ListHyperParameterTuningJobs lists SageMaker hyperparameter tuning jobs.
+func (a *Aws) ListHyperParameterTuningJobs(kt *kit.Kit,
+	opt *adtsm.AwsListHyperParameterTuningJobsOption) (*smv2.ListHyperParameterTuningJobsOutput, error) {
+
+	client, err := a.clientSet.sageMakerV2Client(opt.Region)
+	if err != nil {
+		return nil, err
+	}
+
+	input := &smv2.ListHyperParameterTuningJobsInput{
+		CreationTimeAfter:      opt.CreationTimeAfter,
+		CreationTimeBefore:     opt.CreationTimeBefore,
+		LastModifiedTimeAfter:  opt.LastModifiedTimeAfter,
+		LastModifiedTimeBefore: opt.LastModifiedTimeBefore,
+		MaxResults:             opt.MaxResults,
+		NextToken:              opt.NextToken,
+	}
+	if opt.NameContains != "" {
+		input.NameContains = converter.StrNilPtr(opt.NameContains)
+	}
+	if opt.SortBy != "" {
+		input.SortBy = smtypes.HyperParameterTuningJobSortByOptions(opt.SortBy)
+	}
+	if opt.SortOrder != "" {
+		input.SortOrder = smtypes.SortOrder(opt.SortOrder)
+	}
+	if opt.StatusEquals != "" {
+		input.StatusEquals = smtypes.HyperParameterTuningJobStatus(opt.StatusEquals)
+	}
+
+	resp, err := client.ListHyperParameterTuningJobs(kt.Ctx, input)
+	if err != nil {
+		logs.Errorf("list aws sagemaker hyperparameter tuning jobs failed, err: %v, rid: %s", err, kt.Rid)
+		return nil, err
+	}
+	return resp, nil
+}
+
+// DescribeHyperParameterTuningJob describes a SageMaker hyperparameter tuning job.
+func (a *Aws) DescribeHyperParameterTuningJob(kt *kit.Kit,
+	opt *adtsm.AwsDescribeHyperParameterTuningJobOption) (*smv2.DescribeHyperParameterTuningJobOutput, error) {
+
+	client, err := a.clientSet.sageMakerV2Client(opt.Region)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.DescribeHyperParameterTuningJob(kt.Ctx, &smv2.DescribeHyperParameterTuningJobInput{
+		HyperParameterTuningJobName: converter.StrNilPtr(opt.HyperParameterTuningJobName),
+	})
+	if err != nil {
+		logs.Errorf("describe aws sagemaker hyperparameter tuning job failed, err: %v, rid: %s", err, kt.Rid)
+		return nil, err
+	}
+	return resp, nil
+}
+
 // ListProcessingJobs lists SageMaker processing jobs.
 func (a *Aws) ListProcessingJobs(kt *kit.Kit,
 	opt *adtsm.AwsListProcessingJobsOption) (*smv2.ListProcessingJobsOutput, error) {

--- a/pkg/adaptor/types/sagemaker/aws.go
+++ b/pkg/adaptor/types/sagemaker/aws.go
@@ -105,6 +105,27 @@ type AwsDescribeTrainingJobOption struct {
 	TrainingJobName string
 }
 
+// AwsListHyperParameterTuningJobsOption defines list filters for hyperparameter tuning jobs.
+type AwsListHyperParameterTuningJobsOption struct {
+	Region                 string
+	CreationTimeAfter      *time.Time
+	CreationTimeBefore     *time.Time
+	LastModifiedTimeAfter  *time.Time
+	LastModifiedTimeBefore *time.Time
+	MaxResults             *int32
+	NameContains           string
+	NextToken              *string
+	SortBy                 string
+	SortOrder              string
+	StatusEquals           string
+}
+
+// AwsDescribeHyperParameterTuningJobOption defines the hyperparameter tuning job to describe.
+type AwsDescribeHyperParameterTuningJobOption struct {
+	Region                      string
+	HyperParameterTuningJobName string
+}
+
 // AwsListProcessingJobsOption defines list filters for processing jobs.
 type AwsListProcessingJobsOption struct {
 	Region                 string

--- a/pkg/api/hc-service/sagemaker/aws.go
+++ b/pkg/api/hc-service/sagemaker/aws.go
@@ -188,6 +188,37 @@ func (req *AwsAssumeRoleSageMakerDescribeTrainingJobReq) Validate() error {
 	return validator.Validate.Struct(req)
 }
 
+// AwsAssumeRoleSageMakerListHyperParameterTuningJobsReq lists hyperparameter tuning jobs via AssumeRole.
+type AwsAssumeRoleSageMakerListHyperParameterTuningJobsReq struct {
+	AwsAssumeRoleSageMakerBaseReq `json:",inline"`
+	CreationTimeAfter             *time.Time `json:"creation_time_after,omitempty"`
+	CreationTimeBefore            *time.Time `json:"creation_time_before,omitempty"`
+	LastModifiedTimeAfter         *time.Time `json:"last_modified_time_after,omitempty"`
+	LastModifiedTimeBefore        *time.Time `json:"last_modified_time_before,omitempty"`
+	MaxResults                    *int32     `json:"max_results,omitempty" validate:"omitempty,min=1"`
+	NameContains                  string     `json:"name_contains,omitempty"`
+	NextToken                     string     `json:"next_token,omitempty"`
+	SortBy                        string     `json:"sort_by,omitempty"`
+	SortOrder                     string     `json:"sort_order,omitempty"`
+	StatusEquals                  string     `json:"status_equals,omitempty"`
+}
+
+// Validate validates the request.
+func (req *AwsAssumeRoleSageMakerListHyperParameterTuningJobsReq) Validate() error {
+	return validator.Validate.Struct(req)
+}
+
+// AwsAssumeRoleSageMakerDescribeHyperParameterTuningJobReq describes a hyperparameter tuning job via AssumeRole.
+type AwsAssumeRoleSageMakerDescribeHyperParameterTuningJobReq struct {
+	AwsAssumeRoleSageMakerBaseReq `json:",inline"`
+	HyperParameterTuningJobName   string `json:"hyper_parameter_tuning_job_name" validate:"required"`
+}
+
+// Validate validates the request.
+func (req *AwsAssumeRoleSageMakerDescribeHyperParameterTuningJobReq) Validate() error {
+	return validator.Validate.Struct(req)
+}
+
 // AwsAssumeRoleSageMakerListProcessingJobsReq lists processing jobs via AssumeRole.
 type AwsAssumeRoleSageMakerListProcessingJobsReq struct {
 	AwsAssumeRoleSageMakerBaseReq `json:",inline"`

--- a/pkg/client/hc-service/aws/sagemaker.go
+++ b/pkg/client/hc-service/aws/sagemaker.go
@@ -94,6 +94,20 @@ func (c *SageMakerClient) GetTrainingJob(kt *kit.Kit,
 	return requestRaw(c.client, kt, request, "/assume_role/sagemaker/training_jobs/get")
 }
 
+// ListHyperParameterTuningJobs lists hyperparameter tuning jobs via AssumeRole cross-account access.
+func (c *SageMakerClient) ListHyperParameterTuningJobs(kt *kit.Kit,
+	request *proto.AwsAssumeRoleSageMakerListHyperParameterTuningJobsReq) (stdjson.RawMessage, error) {
+
+	return requestRaw(c.client, kt, request, "/assume_role/sagemaker/hyper_parameter_tuning_jobs/list")
+}
+
+// GetHyperParameterTuningJob gets a hyperparameter tuning job via AssumeRole cross-account access.
+func (c *SageMakerClient) GetHyperParameterTuningJob(kt *kit.Kit,
+	request *proto.AwsAssumeRoleSageMakerDescribeHyperParameterTuningJobReq) (stdjson.RawMessage, error) {
+
+	return requestRaw(c.client, kt, request, "/assume_role/sagemaker/hyper_parameter_tuning_jobs/get")
+}
+
 // ListProcessingJobs lists processing jobs via AssumeRole cross-account access.
 func (c *SageMakerClient) ListProcessingJobs(kt *kit.Kit,
 	request *proto.AwsAssumeRoleSageMakerListProcessingJobsReq) (stdjson.RawMessage, error) {


### PR DESCRIPTION
## Summary
- Add full-chain AWS SageMaker HyperParameterTuningJob list/get passthrough APIs.
- Wire request types, adaptor options, AWS SDK adaptor calls, hc-service/cloud-server routes, and hc-service client methods.
- Add API Gateway YAML and web-server Markdown docs for the new list/get resources.
- Set all AWS SageMaker API Gateway resources to `isPublic: false`, `allowApplyPermission: false`, and `userVerifiedRequired: false`.

## Verification
- `go test ./cmd/hc-service/service/sagemaker ./cmd/cloud-server/service/sagemaker ./pkg/adaptor/aws ./pkg/client/hc-service/aws ./pkg/api/hc-service/sagemaker ./pkg/adaptor/types/sagemaker`
- `git diff --check`
- Parsed `docs/api-docs/api-server/api/bk_apigw_resources_bk-hcm.yaml` and verified 31 AWS SageMaker resources have the requested gateway flags set to false.
- `$code-review`: code-reviewer APPROVE, architect CLEAR.
