### PR TITLE
feat: 负载均衡-名称支持英文点号 --story=136645087

### DIFF
--- a/front/src/views/service/service-apply/clb/hooks/useRenderForm.tsx
+++ b/front/src/views/service/service-apply/clb/hooks/useRenderForm.tsx
@@ -142,8 +142,8 @@ export default (formModel: Reactive<ApplyClbModel>) => {
     name: [
       {
         validator: (value: string) =>
-          /^(?=.{1,60}$)[\u4E00-\u9FA5A-Za-z0-9]([\u4E00-\u9FA5A-Za-z0-9-]*[\u4E00-\u9FA5A-Za-z0-9])?$/.test(value),
-        message: '60个字符，支持中文、字母、数字、“-”，且必须以中文、字母、数字开头和结尾。',
+          /^(?=.{1,60}$)[\u4E00-\u9FA5A-Za-z0-9]([\u4E00-\u9FA5A-Za-z0-9.-]*[\u4E00-\u9FA5A-Za-z0-9])?$/.test(value),
+        message: '60个字符，支持中文、字母、数字、“-”与“.”，且必须以中文、字母、数字开头和结尾。',
         trigger: 'change',
       },
     ],


### PR DESCRIPTION
## 变更说明

同步内部版同名改动：CLB 实例名称校验放开英文点号（.），与后端放开保持一致。

- 名称校验正则中部字符类加入 \.\`n- 提示文案同步更新
- 首尾仍须为中文/字母/数字，长度 1-60 不变

## 影响范围

仅前端 front/src/views/service/service-apply/clb/hooks/useRenderForm.tsx