### PR TITLE
feat: 负载均衡-监听器-证书字段回填反了 --story=137359493

### DIFF
--- a/front/src/views/load-balancer/children/display/field-listener.ts
+++ b/front/src/views/load-balancer/children/display/field-listener.ts
@@ -63,11 +63,11 @@ export class DisplayFieldListener {
   @Column('enum', { name: '认证方式', index: 0, option: SSL_MODE_NAME, width: 120 })
   'certificate.ssl_mode': string;
 
-  @Column('string', { name: '服务器证书', index: 0, width: 120 })
-  'certificate.ca_cloud_id': string;
-
-  @Column('array', { name: 'CA证书', index: 0, width: 120 })
+  @Column('array', { name: '服务器证书', index: 0, width: 120 })
   'certificate.cert_cloud_ids': string[];
+
+  @Column('string', { name: 'CA证书', index: 0, width: 120 })
+  'certificate.ca_cloud_id': string;
 
   // 组合字段
   @Column('json', { name: 'RS权重不为0数 / RS总数', width: 120 })


### PR DESCRIPTION
对调 field-listener.ts 中服务器证书与 CA 证书的字段路径绑定，使其列名正确映射：服务器证书=certificate.cert_cloud_ids，CA证书=certificate.ca_cloud_id。DisplayFieldListener 被监听器列表、详情及预览等展示面共用，一处修改即可修复全部证书展示。