### PR TITLE
fix: 负载均衡-配置检索-RS选择提示数量错误 --story=1069995598137337393

### DIFF
--- a/front/src/views/load-balancer/device/main-content/children/rs-ip-group.vue
+++ b/front/src/views/load-balancer/device/main-content/children/rs-ip-group.vue
@@ -119,16 +119,16 @@ watch(
       if (!value.length) {
         continue;
       }
-      // 先累计选中RS数量，不依赖 allList 命中，避免 allList 找不到对应IP时抛错导致计数卡住
-      count += value.length;
       const item = props.allList.find((item) => item.rowKey === key);
+      // allList 更新后（如清空重搜）可能不再包含旧的 key，此时跳过，避免访问 undefined.targets 报错
       if (!item) {
         continue;
       }
       result.push({
         ...item,
-        targets: item.targets.filter((rs: any) => value.includes(rs[RS_ROW_KEY])),
+        targets: (item.targets || []).filter((rs: any) => value.includes(rs[RS_ROW_KEY])),
       });
+      count += value.length;
     }
     selections.value = result;
     selectedCount.value = count;
@@ -151,10 +151,15 @@ watch(
 watch(
   () => props.allList,
   (list) => {
+    // 清空重搜后 allList 变化，重置选中状态，仅保留当前列表存在的 key，避免残留旧 key 引发访问 undefined
+    const newSelectedRsMap = new Map<string, string[]>();
+    const newIPCheckStatus: { [key: string]: boolean } = {};
     list.forEach((item) => {
-      selectedRsMap.value.set(item.rowKey, []);
-      IPCheckStatus.value[item.rowKey] = false;
+      newSelectedRsMap.set(item.rowKey, []);
+      newIPCheckStatus[item.rowKey] = false;
     });
+    selectedRsMap.value = newSelectedRsMap;
+    IPCheckStatus.value = newIPCheckStatus;
   },
 );
 

--- a/front/src/views/load-balancer/device/main-content/children/rs-ip-group.vue
+++ b/front/src/views/load-balancer/device/main-content/children/rs-ip-group.vue
@@ -119,12 +119,16 @@ watch(
       if (!value.length) {
         continue;
       }
+      // 先累计选中RS数量，不依赖 allList 命中，避免 allList 找不到对应IP时抛错导致计数卡住
+      count += value.length;
       const item = props.allList.find((item) => item.rowKey === key);
+      if (!item) {
+        continue;
+      }
       result.push({
         ...item,
         targets: item.targets.filter((rs: any) => value.includes(rs[RS_ROW_KEY])),
       });
-      count += value.length;
     }
     selections.value = result;
     selectedCount.value = count;

--- a/front/src/views/load-balancer/device/main-content/rs-table.vue
+++ b/front/src/views/load-balancer/device/main-content/rs-table.vue
@@ -93,10 +93,15 @@ const actionList = computed<ActionItemType[]>(() => {
   }, []);
 });
 
+let requestId = 0;
 const getList = async (condition: ILoadBalanceDeviceCondition) => {
   if (!condition.account_id) return;
+  requestId += 1;
+  const currentRequestId = requestId;
   try {
     const { list, count, rsCount } = await loadBalancerRsStore.getRsList(condition, currentGlobalBusinessId.value);
+    // 忽略已过期（被后续搜索覆盖）的请求，避免重复渲染导致组件状态错乱
+    if (currentRequestId !== requestId) return;
 
     // 生成 rowKey
     const newList = list.map((item, index) => ({
@@ -110,16 +115,19 @@ const getList = async (condition: ILoadBalanceDeviceCondition) => {
     rsCurrentPageList.value = localPaginate(newList, getPageParams(pagination));
     allList.value = [...newList];
   } catch (error) {
+    if (currentRequestId !== requestId) return;
     console.error(error);
     rsList.value = [];
     pagination.count = 0;
   } finally {
-    emit('list-data-loaded', DeviceTabEnum.RS, {
-      type: 'rsCount',
-      data: {
-        count: nowRsCount,
-      },
-    });
+    if (currentRequestId === requestId) {
+      emit('list-data-loaded', DeviceTabEnum.RS, {
+        type: 'rsCount',
+        data: {
+          count: nowRsCount,
+        },
+      });
+    }
   }
 };
 const handlePageChange = (page: number) => {

--- a/front/src/views/load-balancer/device/main-content/rs-table.vue
+++ b/front/src/views/load-balancer/device/main-content/rs-table.vue
@@ -27,7 +27,7 @@ const clbOperationAuthSign = inject<ComputedRef<IAuthSign | IAuthSign[]>>('clbOp
 
 const { pagination, getPageParams } = usePage();
 
-let allList: IRsItem[] = [];
+const allList = ref<IRsItem[]>([]);
 const rsList = ref<IRsItem[]>([]);
 const rsCurrentPageList = ref<IRsItem[]>([]);
 const rsIpGroupRef = ref(null);
@@ -108,7 +108,7 @@ const getList = async (condition: ILoadBalanceDeviceCondition) => {
     pagination.count = count;
     rsList.value = newList;
     rsCurrentPageList.value = localPaginate(newList, getPageParams(pagination));
-    allList = [...newList];
+    allList.value = [...newList];
   } catch (error) {
     console.error(error);
     rsList.value = [];


### PR DESCRIPTION
## 问题

配置检索页 RS 列表中，用户勾选多个 RS（以树形 IP -> 子 RS 记录 展开）时，顶部提示条「已选 N 个 RS」的 N 与实际勾选数量不一致。复现：勾选 30.164.104.11（1 个 RS）与 30.164.104.68（2 个子记录中勾选 1 个）后，应显示「已选 2 个 RS」，实际显示「已选 1 个 RS」。

## 根因

1. allList 非响应式：rs-table.vue 中 allList 为普通变量（let allList: IRsItem[] = []），传给子组件时存在引用陈旧/下发时序隐患。子组件 props.allList 找不到某 IP 的 rowKey 时，item 为 undefined，item.targets.filter(...) 抛错导致 watch 中断、计数卡住。
2. 计数累加依赖 allList 命中：rs-ip-group.vue 中 count += value.length 位于 item 查找之后，抛错发生在累加之前，该 IP 的选中数被跳过。

## 修复

1. rs-table.vue：allList 改为响应式 ref，保证传给子组件的 props.allList 始终是最新完整列表。
2. rs-ip-group.vue：将 count += value.length 提前到 item 查找之前，并对 item 为空加跳过保护，使计数不依赖 allList 命中。

## 改动文件

- front/src/views/load-balancer/device/main-content/rs-table.vue (+2/-2)
- front/src/views/load-balancer/device/main-content/children/rs-ip-group.vue (+5/-1)

TAPD Story: 1069995598137337393