### PR TITLE
feat: 安全组-克隆支持选择目标地域 --story=136749088

### DIFF
--- a/front/src/language/lang.ts
+++ b/front/src/language/lang.ts
@@ -1031,6 +1031,7 @@ const lang: ILANG = {
   子网名称: ['Subnet name'],
   安全组ID: ['Security group ID'],
   安全组名称: ['Security group name'],
+  '已克隆至 {region}！': ['Cloned to {region}!'],
   本地存储ID: ['Local storage ID'],
   本地存储名称: ['Local storage name'],
   对象存储ID: ['Object Storage ID'],

--- a/front/src/store/business.ts
+++ b/front/src/store/business.ts
@@ -13,6 +13,7 @@ export interface ICloneSecurityParams {
   name: string;
   manager: string;
   bak_manager: string;
+  target_region: string;
 }
 // 获取
 const getBusinessApiPath = () => {
@@ -73,11 +74,12 @@ export const useBusinessStore = defineStore({
      * @return {*}
      */
     cloneSecurity(data: ICloneSecurityParams) {
-      const { id, name, manager, bak_manager } = data;
+      const { id, name, manager, bak_manager, target_region } = data;
       return http.post(`${BK_HCM_AJAX_URL_PREFIX}/api/v1/cloud/${getBusinessApiPath()}security_groups/${id}/clone`, {
         name,
         manager,
         bak_manager,
+        target_region,
       });
     },
     addEip(id: number, data: any, isRes = false) {

--- a/front/src/views/resource/resource-manage/children/dialog/clone-security/index.vue
+++ b/front/src/views/resource/resource-manage/children/dialog/clone-security/index.vue
@@ -2,7 +2,8 @@
 <script setup lang="ts">
 import { Dialog, Form, Message } from 'bkui-vue';
 import { ref, computed, h, reactive, watch, useTemplateRef } from 'vue';
-import { useResourceStore, useBusinessStore, useRegionStore } from '@/store';
+import { useResourceStore, useBusinessStore } from '@/store';
+import { useRegionStore } from '@/store/region';
 
 import UsageBizValue from '../../components/security/usage-biz-value.vue';
 import SecurityGroupManagerSelector from '@/views/resource/resource-manage/children/components/security/manager-selector/index.vue';
@@ -213,12 +214,12 @@ const inColumns: any = computed(() =>
       render({ row }: any) {
         return h('span', {}, [
           vendor.value === 'huawei'
-            ? HuaweiSecurityRuleEnum[row.action]
+            ? (HuaweiSecurityRuleEnum as Record<string, string>)[row.action]
             : vendor.value === 'azure'
-            ? AzureSecurityRuleEnum[row.access]
+            ? (AzureSecurityRuleEnum as Record<string, string>)[row.access]
             : vendor.value === 'aws'
             ? t('允许')
-            : SecurityRuleEnum[row.action] || '--',
+            : (SecurityRuleEnum as Record<string, string>)[row.action] || '--',
         ]);
       },
       isShow: vendor.value !== 'aws',
@@ -381,12 +382,12 @@ const outColumns: any = computed(() =>
       render({ row }: any) {
         return h('span', {}, [
           vendor.value === 'huawei'
-            ? HuaweiSecurityRuleEnum[row.action]
+            ? (HuaweiSecurityRuleEnum as Record<string, string>)[row.action]
             : vendor.value === 'azure'
-            ? AzureSecurityRuleEnum[row.access]
+            ? (AzureSecurityRuleEnum as Record<string, string>)[row.access]
             : vendor.value === 'aws'
             ? t('允许')
-            : SecurityRuleEnum[row.action] || '--',
+            : (SecurityRuleEnum as Record<string, string>)[row.action] || '--',
         ]);
       },
       isShow: vendor.value !== 'aws',

--- a/front/src/views/resource/resource-manage/children/dialog/clone-security/index.vue
+++ b/front/src/views/resource/resource-manage/children/dialog/clone-security/index.vue
@@ -2,7 +2,7 @@
 <script setup lang="ts">
 import { Dialog, Form, Message } from 'bkui-vue';
 import { ref, computed, h, reactive, watch, useTemplateRef } from 'vue';
-import { useResourceStore, useBusinessStore } from '@/store';
+import { useResourceStore, useBusinessStore, useRegionStore } from '@/store';
 
 import UsageBizValue from '../../components/security/usage-biz-value.vue';
 import SecurityGroupManagerSelector from '@/views/resource/resource-manage/children/components/security/manager-selector/index.vue';
@@ -49,13 +49,30 @@ const states = reactive<any>({
 });
 const filter = ref({ op: QueryRuleOPEnum.AND, rules: [{ field: 'type', op: QueryRuleOPEnum.EQ, value: 'ingress' }] });
 const personSelectorRef = ref(null);
-const formModel = reactive({ name: `${props.data.name}-copy` });
+const formModel = reactive({ name: `${props.data.name}-copy`, targetRegion: props?.data?.region });
 const formRef = useTemplateRef<typeof Form>('formRef');
 const rules = {
   name: [{ validator: (val: string) => val.length <= 60, message: t('名称超过60个字符的长度限制，请调整后重试') }],
+  targetRegion: [{ validator: (val: string) => !!val, message: t('目标地域不能为空') }],
 };
 
 const vendor = computed(() => props?.data?.vendor);
+
+// 目标地域
+const regionStore = useRegionStore();
+const regionList = ref<{ id: string; name: string }[]>([]);
+const regionLoading = ref(false);
+const getRegionList = async () => {
+  regionLoading.value = true;
+  try {
+    regionList.value = (await regionStore.getRegionList({ vendor: vendor.value as VendorEnum })) || [];
+  } catch (e) {
+    console.error(e);
+    regionList.value = [];
+  } finally {
+    regionLoading.value = false;
+  }
+};
 
 const inColumns: any = computed(() =>
   [
@@ -420,8 +437,13 @@ const handleConfirm = async () => {
       name: formModel.name,
       bak_manager,
       manager,
+      target_region: formModel.targetRegion,
     });
-    Message({ theme: 'success', message: t('克隆成功！') });
+    const targetRegionName = regionList.value.find((item) => item.id === formModel.targetRegion)?.name;
+    Message({
+      theme: 'success',
+      message: t('已克隆至 {region}！', { region: targetRegionName || formModel.targetRegion }),
+    });
     handleClose();
     emit('success');
   } finally {
@@ -432,7 +454,10 @@ const handleConfirm = async () => {
 watch(
   () => props.isShow,
   (val: boolean) => {
-    if (val) getList();
+    if (val) {
+      getList();
+      getRegionList();
+    }
   },
   {
     immediate: true,
@@ -474,6 +499,11 @@ watch(
     <bk-form ref="formRef" :model="formModel" :rules="rules" form-type="vertical">
       <bk-form-item :label="t('安全组名称')" property="name" label-width="100">
         <bk-input v-model.trim="formModel.name" />
+      </bk-form-item>
+      <bk-form-item :label="t('目标地域')" property="targetRegion" label-width="100">
+        <bk-select v-model="formModel.targetRegion" filterable :loading="regionLoading">
+          <bk-option v-for="item in regionList" :key="item.id" :id="item.id" :name="item.name" />
+        </bk-select>
       </bk-form-item>
     </bk-form>
     <SecurityGroupManagerSelector

--- a/front/src/views/resource/resource-manage/children/dialog/security-group/change-confirm.vue
+++ b/front/src/views/resource/resource-manage/children/dialog/security-group/change-confirm.vue
@@ -10,10 +10,9 @@ import DisplayValue from '@/components/display-value/index.vue';
 import RelResourcesDisplay from '../../components/security/rel-resources-display.vue';
 import hintIcon from '@/assets/image/hint.svg';
 
+const model = defineModel<boolean>();
 const props = defineProps<{ detail: ISecurityGroupOperateItem; loading: boolean }>();
 const emit = defineEmits(['confirm']);
-const model = defineModel<boolean>();
-
 const { t } = useI18n();
 
 const fields = [
@@ -86,7 +85,6 @@ const handleClosed = () => {
 
 <style scoped lang="scss">
 .hint-wrap {
-  margin-top: -35px;
   text-align: center;
 
   img {

--- a/front/src/views/resource/resource-manage/children/dialog/security-group/single-delete.vue
+++ b/front/src/views/resource/resource-manage/children/dialog/security-group/single-delete.vue
@@ -11,8 +11,8 @@ import hintIcon from '@/assets/image/hint.svg';
 import DeleteButton from './single-delete-button.plugin.vue';
 
 defineOptions({ name: 'security-group-delete-dialog' });
-const props = defineProps<{ detail: ISecurityGroupOperateItem; loading: boolean }>();
 const model = defineModel<boolean>();
+const props = defineProps<{ detail: ISecurityGroupOperateItem; loading: boolean }>();
 const emit = defineEmits(['success']);
 
 const { t } = useI18n();
@@ -95,7 +95,6 @@ const handleClosed = () => {
 
 <style scoped lang="scss">
 .hint-wrap {
-  margin-top: -35px;
   text-align: center;
 
   img {


### PR DESCRIPTION
## What

安全组克隆弹窗新增「目标地域」选择：

- 弹窗表单新增目标地域下拉，默认为源安全组所在地域，可切换为该 vendor 可用的地域全集（复用 `useRegionStore.getRegionList`）
- 克隆接口透传 `target_region` 参数
- 成功提示改为「已克隆至 {region}！」，并补充对应文案
- 附带克隆弹窗内枚举索引的 TS 类型修复与 region store 导入路径调整

## How

从内部版本同步以下提交并适配开源仓结构：

- feat: 安全组-克隆支持选择目标地域 --story=136749088
- fix: 克隆安全组弹窗枚举索引TS类型修复与region store导入路径调整
- fix: 克隆安全组成功提示目标地域占位符未替换 --story=136749088
- fix: 安全组删除弹窗提示区去掉负外边距避免布局偏移
