### PR TITLE
feat: 负载均衡条件同步异步进度 --story=136313446

### DIFF
--- a/cmd/cloud-server/etc/cloud_server.yaml
+++ b/cmd/cloud-server/etc/cloud_server.yaml
@@ -305,6 +305,18 @@ ccHostPoolBiz: 1
 
 concurrentConfig:
   clbImportCount: 10
+  # clbCondSync 负载均衡条件同步的任务分批与启动拉云配置，缺省时使用默认值
+  clbCondSync:
+    # deleteBatchSize 单个清理任务动作处理的负载均衡数量，默认 100
+    deleteBatchSize: 100
+    # upsertBatchSize 单个同步任务动作处理的负载均衡数量，默认 500
+    upsertBatchSize: 500
+    # largeUpsertThreshold 待同步负载均衡数量超过该阈值时改用 largeUpsertBatchSize 分批，默认 10000
+    largeUpsertThreshold: 10000
+    # largeUpsertBatchSize 待同步数量超过阈值后，单个同步任务动作处理的负载均衡数量，默认 2500
+    largeUpsertBatchSize: 2500
+    # listConcurrent 启动阶段单地域拉取云上简要信息的分页并发，默认 5
+    listConcurrent: 5
 
 # tmp file dir, default: /tmp
 tmpFileDir: /tmp

--- a/cmd/cloud-server/logics/load-balancer/cond_sync.go
+++ b/cmd/cloud-server/logics/load-balancer/cond_sync.go
@@ -1,0 +1,141 @@
+/*
+ *
+ * TencentBlueKing is pleased to support the open source community by making
+ * 蓝鲸智云 - 混合云管理平台 (BlueKing - Hybrid Cloud Management System) available.
+ * Copyright (C) 2024 THL A29 Limited,
+ * a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * We undertake not to change the open source license (MIT license) applicable
+ *
+ * to the current version of the project delivered to anyone in the future.
+ */
+
+package lblogic
+
+import (
+	"time"
+
+	"hcm/pkg/api/core"
+	corelb "hcm/pkg/api/core/cloud/load-balancer"
+	"hcm/pkg/client"
+	"hcm/pkg/criteria/constant"
+	"hcm/pkg/criteria/enumor"
+	"hcm/pkg/kit"
+	"hcm/pkg/logs"
+	cvt "hcm/pkg/tools/converter"
+	"hcm/pkg/tools/slice"
+)
+
+// CondSyncLoadBalancerOption 负载均衡条件同步的厂商无关参数
+type CondSyncLoadBalancerOption struct {
+	// Vendor 云厂商，当前支持 tcloud
+	Vendor enumor.Vendor
+	// AccountID 账号ID
+	AccountID string
+	// BkBizID 业务ID，未分配业务时为 constant.UnassignedBiz
+	BkBizID int64
+	// Regions 本次同步的地域列表
+	Regions []string
+	// CloudIDs 本次同步指定的云上ID，为空表示地域全量
+	CloudIDs []string
+	// TagFilters 标签过滤条件
+	TagFilters core.MultiValueTagMap
+}
+
+// LoadBalancerRegionDiff 单个地域云上与DB的差异，create/update 来自云上，delete 来自DB
+type LoadBalancerRegionDiff struct {
+	Region string
+	Create []corelb.LoadBalancerBrief
+	Update []corelb.LoadBalancerBrief
+	Delete []corelb.LoadBalancerBrief
+}
+
+// ListAndDiffLoadBalancerByRegion 查询单个地域云上与DB的负载均衡并计算差异
+func ListAndDiffLoadBalancerByRegion(kt *kit.Kit, cliSet *client.ClientSet, opt *CondSyncLoadBalancerOption,
+	region string) (*LoadBalancerRegionDiff, error) {
+
+	listOpt := &ListLoadBalancerBriefOption{
+		Vendor:     opt.Vendor,
+		AccountID:  opt.AccountID,
+		Region:     region,
+		CloudIDs:   opt.CloudIDs,
+		TagFilters: opt.TagFilters,
+	}
+	// 腾讯云上没有业务概念，业务入口下先按 bk_biz_id 查DB，再用查出的云上ID收敛云上查询范围。
+	isBizEntry := opt.BkBizID != 0 && opt.BkBizID != constant.UnassignedBiz
+	if isBizEntry {
+		listOpt.BkBizID = cvt.ValToPtr(opt.BkBizID)
+	}
+	// DB查询先于云上查询，一是收敛云上范围需要DB结果，二是同步期间入库的实例只会被判为新增而非删除。
+	dbStartedAt := time.Now()
+	dbLBs, err := ListLoadBalancerBriefFromDB(kt, cliSet.DataService(), listOpt)
+	if err != nil {
+		logs.Errorf("list db load balancer brief failed, err: %v, account: %s, region: %s, rid: %s",
+			err, opt.AccountID, region, kt.Rid)
+		return nil, err
+	}
+	logs.Infof("list db load balancer brief done, account: %s, region: %s, count: %d, cost: %s, rid: %s",
+		opt.AccountID, region, len(dbLBs), time.Since(dbStartedAt), kt.Rid)
+
+	if isBizEntry && opt.Vendor == enumor.TCloud {
+		// 业务下没有负载均衡时无需查询云上，云上多出来的实例不属于本业务，其新建由资源侧入口负责。
+		if len(dbLBs) == 0 {
+			return &LoadBalancerRegionDiff{Region: region}, nil
+		}
+		listOpt.CloudIDs = slice.Map(dbLBs, func(one corelb.LoadBalancerBrief) string { return one.CloudID })
+	}
+
+	cloudStartedAt := time.Now()
+	cloudLBs, err := ListLoadBalancerBriefFromCloud(kt, cliSet, listOpt)
+	if err != nil {
+		logs.Errorf("list cloud load balancer brief failed, err: %v, account: %s, region: %s, rid: %s",
+			err, opt.AccountID, region, kt.Rid)
+		return nil, err
+	}
+	logs.Infof("list cloud load balancer brief done, account: %s, region: %s, count: %d, cost: %s, rid: %s",
+		opt.AccountID, region, len(cloudLBs), time.Since(cloudStartedAt), kt.Rid)
+
+	diff := DiffLoadBalancerBrief(region, cloudLBs, dbLBs)
+	logs.Infof("diff conditional sync load balancer done, account: %s, region: %s, create: %d, update: %d, "+
+		"delete: %d, rid: %s", opt.AccountID, region, len(diff.Create), len(diff.Update), len(diff.Delete), kt.Rid)
+
+	return diff, nil
+}
+
+// DiffLoadBalancerBrief 按云上ID对比云上与DB的负载均衡，得到单个地域的差异。
+func DiffLoadBalancerBrief(region string, cloudLBs, dbLBs []corelb.LoadBalancerBrief) *LoadBalancerRegionDiff {
+	dbLBMap := cvt.SliceToMap(dbLBs, func(one corelb.LoadBalancerBrief) (string, corelb.LoadBalancerBrief) {
+		return one.CloudID, one
+	})
+
+	diff := &LoadBalancerRegionDiff{Region: region}
+	cloudIDs := make(map[string]struct{}, len(cloudLBs))
+	for _, one := range cloudLBs {
+		if _, exists := cloudIDs[one.CloudID]; exists {
+			continue
+		}
+		cloudIDs[one.CloudID] = struct{}{}
+
+		if _, exists := dbLBMap[one.CloudID]; exists {
+			diff.Update = append(diff.Update, one)
+			continue
+		}
+		diff.Create = append(diff.Create, one)
+	}
+
+	for _, one := range dbLBs {
+		if _, exists := cloudIDs[one.CloudID]; !exists {
+			diff.Delete = append(diff.Delete, one)
+		}
+	}
+
+	return diff
+}

--- a/cmd/cloud-server/logics/load-balancer/cond_sync_executor.go
+++ b/cmd/cloud-server/logics/load-balancer/cond_sync_executor.go
@@ -1,0 +1,573 @@
+/*
+ *
+ * TencentBlueKing is pleased to support the open source community by making
+ * 蓝鲸智云 - 混合云管理平台 (BlueKing - Hybrid Cloud Management System) available.
+ * Copyright (C) 2024 THL A29 Limited,
+ * a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * We undertake not to change the open source license (MIT license) applicable
+ *
+ * to the current version of the project delivered to anyone in the future.
+ */
+
+package lblogic
+
+import (
+	"fmt"
+	"strconv"
+
+	actionlb "hcm/cmd/task-server/logics/action/load-balancer"
+	"hcm/pkg/api/core"
+	corelb "hcm/pkg/api/core/cloud/load-balancer"
+	coretask "hcm/pkg/api/core/task"
+	"hcm/pkg/api/data-service/task"
+	ts "hcm/pkg/api/task-server"
+	"hcm/pkg/async/action"
+	"hcm/pkg/async/backend"
+	"hcm/pkg/async/producer"
+	"hcm/pkg/cc"
+	"hcm/pkg/client"
+	dataservice "hcm/pkg/client/data-service"
+	taskserver "hcm/pkg/client/task-server"
+	"hcm/pkg/criteria/constant"
+	"hcm/pkg/criteria/enumor"
+	"hcm/pkg/criteria/errf"
+	"hcm/pkg/dal/dao/tools"
+	"hcm/pkg/kit"
+	"hcm/pkg/logs"
+	cvt "hcm/pkg/tools/converter"
+	"hcm/pkg/tools/slice"
+)
+
+// CreateCondSyncTask 创建负载均衡条件同步的任务管理与任务流
+func CreateCondSyncTask(kt *kit.Kit, cliSet *client.ClientSet, opt *CondSyncLoadBalancerOption,
+	regionDiffs []LoadBalancerRegionDiff) (string, error) {
+
+	executor := newCondSyncLoadBalancerExecutor(cliSet.DataService(), cliSet.TaskServer(), opt, regionDiffs)
+	return executor.Run(kt)
+}
+
+func newCondSyncLoadBalancerExecutor(cli *dataservice.Client, taskCli *taskserver.Client, opt *CondSyncLoadBalancerOption,
+	regionDiffs []LoadBalancerRegionDiff) *CondSyncLoadBalancerExecutor {
+
+	executor := &CondSyncLoadBalancerExecutor{
+		operationType:  enumor.TaskSyncLoadBalancer,
+		dataServiceCli: cli,
+		taskCli:        taskCli,
+		opt:            opt,
+		bkBizID:        opt.bkBizID(),
+	}
+	executor.batches = executor.buildBatches(regionDiffs)
+
+	return executor
+}
+
+// CondSyncLoadBalancerExecutor 负载均衡条件同步执行器
+type CondSyncLoadBalancerExecutor struct {
+	operationType  enumor.TaskOperation
+	dataServiceCli *dataservice.Client
+	taskCli        *taskserver.Client
+
+	opt *CondSyncLoadBalancerOption
+	// bkBizID 任务记录落库用的业务ID，未分配业务时为 constant.UnassignedBiz
+	bkBizID int64
+	// batches 已按先清理后同步排好序的任务批次，一个批次对应一个任务动作
+	batches []*condSyncLoadBalancerBatch
+}
+
+// condSyncLoadBalancerBatch 一个批次对应一个任务动作，批次内的负载均衡同地域、同操作类型。
+// 云上清理与同步都按地域调用下游接口，因此批次不跨地域。
+type condSyncLoadBalancerBatch struct {
+	region string
+	// isDelete 为真表示清理云上已不存在的负载均衡，否则表示同步云上仍存在的负载均衡
+	isDelete bool
+	// actionID 该批次对应的任务动作ID，构建任务动作时回填
+	actionID string
+	details  []*condSyncTaskDetail
+}
+
+// condSyncTaskDetail 一台负载均衡一条任务详情，taskDetailID 在创建任务详情后回填
+type condSyncTaskDetail struct {
+	taskDetailID string
+	param        *condSyncTaskDetailParam
+}
+
+// condSyncTaskDetailParam is stored in task_detail.param for displaying a single CLB sync item.
+// Field names follow existing CLB task details so the frontend can reuse CLB VIP/ID columns.
+type condSyncTaskDetailParam struct {
+	// Op 本条详情对应的操作，枚举值：create/update/delete，对应页面「类别」列
+	Op enumor.CondSyncLbOperation `json:"op"`
+	// AccountID 账号ID
+	AccountID string `json:"account_id"`
+	// CloudLbID 云上负载均衡ID，对应页面「CLB ID」列
+	CloudLbID string `json:"cloud_lb_id"`
+	// ClbVipDomain 负载均衡 VIP，对应页面「CLB VIP/域名」列，只存单个地址，不与域名拼接
+	ClbVipDomain string `json:"clb_vip_domain"`
+	// Domain 负载均衡域名
+	Domain string `json:"domain"`
+	// Region 地域
+	Region string `json:"region"`
+}
+
+// bkBizID 任务记录落库用的业务ID。
+func (opt *CondSyncLoadBalancerOption) bkBizID() int64 {
+	if opt == nil || opt.BkBizID == 0 {
+		return constant.UnassignedBiz
+	}
+
+	return opt.BkBizID
+}
+
+// Run 执行器执行入口
+func (c *CondSyncLoadBalancerExecutor) Run(kt *kit.Kit) (string, error) {
+	// 创建异步管理任务、任务详情列表
+	taskID, err := c.buildTaskManagementAndDetails(kt)
+	if err != nil {
+		logs.Errorf("create task management and details failed, err: %v, account: %s, rid: %s",
+			err, c.opt.AccountID, kt.Rid)
+		return "", err
+	}
+
+	// 创建Flow
+	flowID, err := c.buildFlow(kt)
+	if err != nil {
+		logs.Errorf("build conditional sync load balancer flow failed, err: %v, account: %s, taskID: %s, rid: %s",
+			err, c.opt.AccountID, taskID, kt.Rid)
+		return "", err
+	}
+
+	// 把Flow跟异步管理任务进行关联
+	if err = c.updateTaskManagementAndDetails(kt, taskID, flowID); err != nil {
+		logs.Errorf("update task management and details failed, err: %v, taskID: %s, flowID: %s, rid: %s",
+			err, taskID, flowID, kt.Rid)
+		return "", err
+	}
+
+	if err = c.startFlow(kt, flowID); err != nil {
+		logs.Errorf("start conditional sync load balancer flow failed, err: %v, taskID: %s, flowID: %s, rid: %s",
+			err, taskID, flowID, kt.Rid)
+		return "", err
+	}
+
+	logs.Infof("create conditional sync load balancer task success, vendor: %s, account: %s, bk_biz_id: %d, "+
+		"taskID: %s, flowID: %s, batchCount: %d, rid: %s", c.opt.Vendor, c.opt.AccountID, c.bkBizID,
+		taskID, flowID, len(c.batches), kt.Rid)
+
+	return taskID, nil
+}
+
+// buildBatches 把各地域差异按先清理后同步的顺序拆成任务批次。
+// 批大小在此处读取配置，不作为编排参数逐层透传。
+func (c *CondSyncLoadBalancerExecutor) buildBatches(
+	regionDiffs []LoadBalancerRegionDiff) []*condSyncLoadBalancerBatch {
+
+	clbCondSync := cc.CloudServer().ConcurrentConfig.ClbCondSync
+	deleteBatchSize := cvt.PtrToVal(clbCondSync.DeleteBatchSize)
+
+	// 待同步的负载均衡数量超过阈值时放大批次，避免任务动作过多导致下游同步 worker 空转开销累积
+	upsertCount := 0
+	for _, diff := range regionDiffs {
+		upsertCount += len(diff.Create) + len(diff.Update)
+	}
+	upsertBatchSize := cvt.PtrToVal(clbCondSync.UpsertBatchSize)
+	if upsertCount > cvt.PtrToVal(clbCondSync.LargeUpsertThreshold) {
+		upsertBatchSize = cvt.PtrToVal(clbCondSync.LargeUpsertBatchSize)
+	}
+
+	// 所有地域的清理批次都排在同步批次之前
+	batches := make([]*condSyncLoadBalancerBatch, 0)
+	for _, diff := range regionDiffs {
+		deletes := c.newTaskDetails(enumor.CondSyncLbOpDelete, diff.Delete)
+		batches = append(batches, splitCondSyncBatch(diff.Region, true, deletes, deleteBatchSize)...)
+	}
+	for _, diff := range regionDiffs {
+		upserts := c.newTaskDetails(enumor.CondSyncLbOpCreate, diff.Create)
+		upserts = append(upserts, c.newTaskDetails(enumor.CondSyncLbOpUpdate, diff.Update)...)
+		batches = append(batches, splitCondSyncBatch(diff.Region, false, upserts, upsertBatchSize)...)
+	}
+
+	return batches
+}
+
+// newTaskDetails 把差异转成任务详情，delete 的展示信息来自DB，create/update 的展示信息来自云上
+func (c *CondSyncLoadBalancerExecutor) newTaskDetails(op enumor.CondSyncLbOperation,
+	briefs []corelb.LoadBalancerBrief) []*condSyncTaskDetail {
+
+	details := make([]*condSyncTaskDetail, 0, len(briefs))
+	for _, brief := range briefs {
+		clbVipDomain := brief.Address
+		if clbVipDomain == "" {
+			clbVipDomain = brief.AddressIPv6
+		}
+		details = append(details, &condSyncTaskDetail{
+			param: &condSyncTaskDetailParam{
+				Op:           op,
+				AccountID:    c.opt.AccountID,
+				CloudLbID:    brief.CloudID,
+				ClbVipDomain: clbVipDomain,
+				Domain:       brief.Domain,
+				Region:       brief.Region,
+			},
+		})
+	}
+
+	return details
+}
+
+func splitCondSyncBatch(region string, isDelete bool, details []*condSyncTaskDetail,
+	batchSize int) []*condSyncLoadBalancerBatch {
+
+	batches := make([]*condSyncLoadBalancerBatch, 0)
+	for _, partDetails := range slice.Split(details, batchSize) {
+		batches = append(batches, &condSyncLoadBalancerBatch{
+			region:   region,
+			isDelete: isDelete,
+			details:  partDetails,
+		})
+	}
+
+	return batches
+}
+
+// buildTaskManagementAndDetails 构建任务管理和详情
+func (c *CondSyncLoadBalancerExecutor) buildTaskManagementAndDetails(kt *kit.Kit) (string, error) {
+	taskID, err := c.createTaskManagement(kt)
+	if err != nil {
+		logs.Errorf("create task management failed, err: %v, account: %s, rid: %s", err, c.opt.AccountID, kt.Rid)
+		return "", err
+	}
+
+	if err = c.createTaskDetails(kt, taskID); err != nil {
+		logs.Errorf("create task details failed, err: %v, taskID: %s, rid: %s", err, taskID, kt.Rid)
+		return "", err
+	}
+
+	return taskID, nil
+}
+
+// createTaskManagement 创建任务管理记录
+func (c *CondSyncLoadBalancerExecutor) createTaskManagement(kt *kit.Kit) (string, error) {
+	createReq := &task.CreateManagementReq{
+		Items: []task.CreateManagementField{
+			{
+				BkBizID:    c.bkBizID,
+				Source:     enumor.TaskManagementSourceAPI.RefineByRequestSource(kt.RequestSource),
+				Vendors:    []enumor.Vendor{c.opt.Vendor},
+				AccountIDs: []string{c.opt.AccountID},
+				Resource:   enumor.TaskManagementResClb,
+				State:      enumor.TaskManagementRunning, // 默认:执行中
+				Operations: []enumor.TaskOperation{c.operationType},
+				Extension:  &coretask.ManagementExt{RegionIDs: c.opt.Regions},
+			},
+		},
+	}
+
+	result, err := c.dataServiceCli.Global.TaskManagement.Create(kt, createReq)
+	if err != nil {
+		logs.Errorf("create dataservice task management failed, err: %v, account: %s, rid: %s",
+			err, c.opt.AccountID, kt.Rid)
+		return "", err
+	}
+
+	if len(result.IDs) == 0 {
+		return "", fmt.Errorf("create task management get new task ids failed")
+	}
+
+	return result.IDs[0], nil
+}
+
+// createTaskDetails 创建任务详情列表，一台负载均衡一条详情
+func (c *CondSyncLoadBalancerExecutor) createTaskDetails(kt *kit.Kit, taskID string) error {
+	details := make([]*condSyncTaskDetail, 0)
+	for _, batch := range c.batches {
+		details = append(details, batch.details...)
+	}
+
+	items := make([]task.CreateDetailField, 0, len(details))
+	for _, detail := range details {
+		items = append(items, task.CreateDetailField{
+			BkBizID:          c.bkBizID,
+			TaskManagementID: taskID,
+			Operation:        c.operationType,
+			State:            enumor.TaskDetailInit,
+			Param:            detail.param,
+		})
+	}
+
+	detailIDs := make([]string, 0, len(items))
+	for _, partItems := range slice.Split(items, int(core.DefaultMaxPageLimit)) {
+		result, err := c.dataServiceCli.Global.TaskDetail.Create(kt, &task.CreateDetailReq{Items: partItems})
+		if err != nil {
+			logs.Errorf("create dataservice task detail failed, err: %v, taskID: %s, rid: %s", err, taskID, kt.Rid)
+			return err
+		}
+		detailIDs = append(detailIDs, result.IDs...)
+	}
+
+	if len(detailIDs) != len(items) {
+		return fmt.Errorf("create task details failed, operation: %s, expect created[%d] task details, but got [%d]",
+			c.operationType, len(items), len(detailIDs))
+	}
+
+	for i, detail := range details {
+		detail.taskDetailID = detailIDs[i]
+	}
+
+	return nil
+}
+
+func (c *CondSyncLoadBalancerExecutor) buildFlow(kt *kit.Kit) (string, error) {
+	flowTasks := c.buildFlowTasks()
+	if len(flowTasks) == 0 {
+		return "", fmt.Errorf("build conditional sync load balancer flow failed, no load balancer need to be synced")
+	}
+
+	addReq := &ts.AddCustomFlowReq{
+		Name:        enumor.FlowBatchTaskSyncLoadBalancer,
+		ShareData:   NewSubmitFlowShareData(c.bkBizID, c.opt.Vendor, OperationType(c.operationType), nil),
+		Tasks:       flowTasks,
+		IsInitState: true,
+	}
+	result, err := c.taskCli.CreateCustomFlow(kt, addReq)
+	if err != nil {
+		logs.Errorf("call taskserver to create conditional sync load balancer custom flow failed, err: %v, "+
+			"account: %s, rid: %s", err, c.opt.AccountID, kt.Rid)
+		return "", err
+	}
+
+	return result.ID, nil
+}
+
+func (c *CondSyncLoadBalancerExecutor) startFlow(kt *kit.Kit, flowID string) error {
+	req := &producer.UpdateCustomFlowStateOption{
+		FlowInfos: []backend.UpdateFlowInfo{{
+			ID:     flowID,
+			Source: enumor.FlowInit,
+			Target: enumor.FlowPending,
+		}},
+	}
+
+	return c.taskCli.UpdateCustomFlowState(kt, req)
+}
+
+// buildFlowTasks 一个批次一个任务动作，动作之间用 depends_on 按批次顺序串行，
+// 前一个动作失败时后续动作不再执行。批次已排好序，因此最后一个清理动作也是第一个同步动作的前置动作。
+func (c *CondSyncLoadBalancerExecutor) buildFlowTasks() []ts.CustomFlowTask {
+	flowTasks := make([]ts.CustomFlowTask, 0, len(c.batches))
+	for i, batch := range c.batches {
+		batch.actionID = strconv.Itoa(i + 1)
+
+		var flowTask ts.CustomFlowTask
+		if batch.isDelete {
+			flowTask = c.buildDeleteFlowTask(batch)
+		} else {
+			flowTask = c.buildUpsertFlowTask(batch)
+		}
+		if i > 0 {
+			flowTask.DependOn = []action.ActIDType{action.ActIDType(c.batches[i-1].actionID)}
+		}
+
+		flowTasks = append(flowTasks, flowTask)
+	}
+
+	return flowTasks
+}
+
+func (c *CondSyncLoadBalancerExecutor) buildDeleteFlowTask(batch *condSyncLoadBalancerBatch) ts.CustomFlowTask {
+	managementDetailIDs, cloudIDs := condSyncBatchIDs(batch.details)
+
+	return ts.CustomFlowTask{
+		ActionID:   action.ActIDType(batch.actionID),
+		ActionName: enumor.ActionBatchTaskSyncLbDelete,
+		Params: &actionlb.BatchTaskSyncLbDeleteOption{
+			Vendor:              c.opt.Vendor,
+			AccountID:           c.opt.AccountID,
+			Region:              batch.region,
+			ManagementDetailIDs: managementDetailIDs,
+			CloudIDs:            cloudIDs,
+		},
+	}
+}
+
+func (c *CondSyncLoadBalancerExecutor) buildUpsertFlowTask(batch *condSyncLoadBalancerBatch) ts.CustomFlowTask {
+	managementDetailIDs, cloudIDs := condSyncBatchIDs(batch.details)
+
+	return ts.CustomFlowTask{
+		ActionID:   action.ActIDType(batch.actionID),
+		ActionName: enumor.ActionBatchTaskSyncLbUpsert,
+		Params: &actionlb.BatchTaskSyncLbUpsertOption{
+			Vendor:              c.opt.Vendor,
+			AccountID:           c.opt.AccountID,
+			Region:              batch.region,
+			ManagementDetailIDs: managementDetailIDs,
+			CloudIDs:            cloudIDs,
+			TagFilters:          c.opt.TagFilters,
+		},
+	}
+}
+
+func condSyncBatchIDs(details []*condSyncTaskDetail) (managementDetailIDs, cloudIDs []string) {
+	managementDetailIDs = make([]string, 0, len(details))
+	cloudIDs = make([]string, 0, len(details))
+	for _, detail := range details {
+		managementDetailIDs = append(managementDetailIDs, detail.taskDetailID)
+		cloudIDs = append(cloudIDs, detail.param.CloudLbID)
+	}
+
+	return managementDetailIDs, cloudIDs
+}
+
+func (c *CondSyncLoadBalancerExecutor) updateTaskManagementAndDetails(kt *kit.Kit, taskID string, flowID string) error {
+
+	if err := c.updateTaskManagement(kt, taskID, []string{flowID}); err != nil {
+		logs.Errorf("update task management failed, err: %v, taskID: %s, flowIDs: %v, rid: %s",
+			err, taskID, []string{flowID}, kt.Rid)
+		return err
+	}
+
+	if err := c.updateTaskDetails(kt, flowID); err != nil {
+		logs.Errorf("update task details failed, err: %v, taskID: %s, flowID: %s, rid: %s",
+			err, taskID, flowID, kt.Rid)
+		return err
+	}
+
+	return nil
+}
+
+func (c *CondSyncLoadBalancerExecutor) updateTaskManagement(kt *kit.Kit, taskID string, flowIDs []string) error {
+	updateReq := &task.UpdateManagementReq{
+		Items: []task.UpdateTaskManagementField{{
+			ID:      taskID,
+			FlowIDs: flowIDs,
+		}},
+	}
+	if err := c.dataServiceCli.Global.TaskManagement.Update(kt, updateReq); err != nil {
+		logs.Errorf("update task management failed, err: %v, taskID: %s, flowIDs: %v, rid: %s",
+			err, taskID, flowIDs, kt.Rid)
+		return err
+	}
+
+	return nil
+}
+
+// updateTaskDetails 更新task_detail的flow_id和task_action_id
+func (c *CondSyncLoadBalancerExecutor) updateTaskDetails(kt *kit.Kit, flowID string) error {
+	// 同一批次内的详情共用flow与动作ID，按ID集合批量更新，避免逐条更新拖慢任务创建
+	for _, batch := range c.batches {
+		for _, partDetails := range slice.Split(batch.details, constant.BatchOperationMaxLimit) {
+			ids := slice.Map(partDetails, func(detail *condSyncTaskDetail) string { return detail.taskDetailID })
+			updateReq := &task.BatchUpdateTaskDetailReq{
+				IDs:           ids,
+				FlowID:        flowID,
+				TaskActionIDs: []string{batch.actionID},
+			}
+			if err := c.dataServiceCli.Global.TaskDetail.BatchUpdate(kt, updateReq); err != nil {
+				logs.Errorf("update task details failed, err: %v, flowID: %s, actionID: %s, count: %d, rid: %s",
+					err, flowID, batch.actionID, len(ids), kt.Rid)
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// taskManagementLister 查询 task_management 的接口。
+type taskManagementLister interface {
+	List(kt *kit.Kit, req *core.ListReq) (*task.ListManagementResult, error)
+}
+
+// flowLister 查询 flow 的接口。
+type flowLister interface {
+	ListFlow(kt *kit.Kit, req *core.ListReq) (*ts.ListFlowResult, error)
+}
+
+// CheckRunningCondSyncTask rejects duplicate CLB conditional sync tasks before doing diff.
+// 按账号维度互斥。
+func CheckRunningCondSyncTask(kt *kit.Kit, mgmtCli taskManagementLister, flowCli flowLister,
+	opt *CondSyncLoadBalancerOption) error {
+
+	expr := tools.ExpressionAnd(
+		tools.RuleEqual("state", enumor.TaskManagementRunning),
+		tools.RuleEqual("resource", enumor.TaskManagementResClb),
+		tools.RuleJsonOverlaps("operations", []enumor.TaskOperation{enumor.TaskSyncLoadBalancer}),
+		tools.RuleJsonOverlaps("vendors", []enumor.Vendor{opt.Vendor}),
+		tools.RuleJsonOverlaps("account_ids", []string{opt.AccountID}),
+	)
+
+	req := &core.ListReq{
+		Filter: expr,
+		Fields: []string{"id", "flow_ids"},
+		Page:   &core.BasePage{Start: 0, Limit: core.DefaultMaxPageLimit},
+	}
+	flowIDs := make([]string, 0)
+	for {
+		resp, err := mgmtCli.List(kt, req)
+		if err != nil {
+			logs.Errorf("list conditional sync load balancer task management failed, err: %v, req: %+v, rid: %s",
+				err, req, kt.Rid)
+			return err
+		}
+
+		for _, management := range resp.Details {
+			flowIDs = append(flowIDs, management.FlowIDs...)
+		}
+
+		if uint(len(resp.Details)) < core.DefaultMaxPageLimit {
+			break
+		}
+		req.Page.Start += uint32(core.DefaultMaxPageLimit)
+	}
+
+	runningFlowID, err := findRunningCondSyncFlow(kt, flowCli, slice.Unique(flowIDs))
+	if err != nil {
+		return err
+	}
+	if runningFlowID == "" {
+		return nil
+	}
+
+	logs.Infof("conditional sync load balancer task is running, vendor: %s, account: %s, bk_biz_id: %d, "+
+		"flow: %s, rid: %s", opt.Vendor, opt.AccountID, opt.bkBizID(), runningFlowID, kt.Rid)
+
+	return errf.Newf(errf.TooManyRequest, "load balancer conditional sync task is running, vendor: %s, "+
+		"account: %s, bk_biz_id: %d", opt.Vendor, opt.AccountID, opt.bkBizID())
+}
+
+// findRunningCondSyncFlow 返回首个未进入终态的flow id，全部终态时返回空串
+func findRunningCondSyncFlow(kt *kit.Kit, flowCli flowLister, flowIDs []string) (string, error) {
+	if len(flowIDs) == 0 {
+		return "", nil
+	}
+
+	for _, batch := range slice.Split(flowIDs, int(core.DefaultMaxPageLimit)) {
+		req := &core.ListReq{
+			Filter: tools.ContainersExpression("id", batch),
+			Fields: []string{"id", "state"},
+			Page:   core.NewDefaultBasePage(),
+		}
+		resp, err := flowCli.ListFlow(kt, req)
+		if err != nil {
+			logs.Errorf("list conditional sync load balancer flow failed, err: %v, req: %+v, rid: %s",
+				err, req, kt.Rid)
+			return "", err
+		}
+
+		for _, flow := range resp.Details {
+			if flow.State != enumor.FlowCancel && flow.State != enumor.FlowSuccess &&
+				flow.State != enumor.FlowFailed {
+				return flow.ID, nil
+			}
+		}
+	}
+
+	return "", nil
+}

--- a/cmd/cloud-server/logics/load-balancer/cond_sync_executor_test.go
+++ b/cmd/cloud-server/logics/load-balancer/cond_sync_executor_test.go
@@ -1,0 +1,482 @@
+/*
+ * TencentBlueKing is pleased to support the open source community by making
+ * 蓝鲸智云 - 混合云管理平台 (BlueKing - Hybrid Cloud Management System) available.
+ * Copyright (C) 2024 THL A29 Limited,
+ * a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * We undertake not to change the open source license (MIT license) applicable
+ * to the current version of the project delivered to anyone in the future.
+ */
+
+package lblogic
+
+import (
+	"encoding/json"
+	"errors"
+	"math"
+	"testing"
+
+	actionlb "hcm/cmd/task-server/logics/action/load-balancer"
+	"hcm/pkg/api/core"
+	coreasync "hcm/pkg/api/core/async"
+	corelb "hcm/pkg/api/core/cloud/load-balancer"
+	coretask "hcm/pkg/api/core/task"
+	"hcm/pkg/api/data-service/task"
+	ts "hcm/pkg/api/task-server"
+	"hcm/pkg/cc"
+	"hcm/pkg/criteria/constant"
+	"hcm/pkg/criteria/enumor"
+	"hcm/pkg/criteria/errf"
+	"hcm/pkg/kit"
+	cvt "hcm/pkg/tools/converter"
+
+	"github.com/stretchr/testify/require"
+)
+
+var cloudServerSetting = new(cc.CloudServerSetting)
+
+func init() {
+	cc.InitRuntime(cloudServerSetting)
+}
+
+func setClbCondSyncConfig(deleteBatchSize, upsertBatchSize int) {
+	// 大批量阈值取整型上限，保证用例走常规批次大小
+	setClbCondSyncLargeConfig(deleteBatchSize, upsertBatchSize, math.MaxInt, upsertBatchSize)
+}
+
+func setClbCondSyncLargeConfig(deleteBatchSize, upsertBatchSize, largeThreshold, largeBatchSize int) {
+	cloudServerSetting.ConcurrentConfig.ClbCondSync = cc.ClbCondSync{
+		DeleteBatchSize:      cvt.ValToPtr(deleteBatchSize),
+		UpsertBatchSize:      cvt.ValToPtr(upsertBatchSize),
+		LargeUpsertThreshold: cvt.ValToPtr(largeThreshold),
+		LargeUpsertBatchSize: cvt.ValToPtr(largeBatchSize),
+	}
+}
+
+func TestBuildBatches(t *testing.T) {
+	setClbCondSyncConfig(2, 3)
+
+	opt := &CondSyncLoadBalancerOption{
+		Vendor:    enumor.TCloud,
+		AccountID: "acc-1",
+	}
+	executor := &CondSyncLoadBalancerExecutor{opt: opt}
+
+	tests := []struct {
+		name        string
+		regionDiffs []LoadBalancerRegionDiff
+		wantBatches []struct {
+			region   string
+			isDelete bool
+			count    int
+		}
+	}{
+		{
+			name:        "empty diffs",
+			regionDiffs: nil,
+			wantBatches: nil,
+		},
+		{
+			name: "single region delete only",
+			regionDiffs: []LoadBalancerRegionDiff{
+				{Region: "ap-guangzhou", Delete: makeBriefs("lb-1", "lb-2", "lb-3")},
+			},
+			wantBatches: []struct {
+				region   string
+				isDelete bool
+				count    int
+			}{
+				{"ap-guangzhou", true, 2},
+				{"ap-guangzhou", true, 1},
+			},
+		},
+		{
+			name: "single region upsert only",
+			regionDiffs: []LoadBalancerRegionDiff{
+				{Region: "ap-guangzhou", Create: makeBriefs("lb-1", "lb-2"), Update: makeBriefs("lb-3")},
+			},
+			wantBatches: []struct {
+				region   string
+				isDelete bool
+				count    int
+			}{
+				{"ap-guangzhou", false, 3},
+			},
+		},
+		{
+			name: "multi region delete before upsert",
+			regionDiffs: []LoadBalancerRegionDiff{
+				{Region: "ap-guangzhou", Delete: makeBriefs("lb-d1"), Create: makeBriefs("lb-c1")},
+				{Region: "ap-shanghai", Delete: makeBriefs("lb-d2"), Create: makeBriefs("lb-c2")},
+			},
+			wantBatches: []struct {
+				region   string
+				isDelete bool
+				count    int
+			}{
+				{"ap-guangzhou", true, 1},
+				{"ap-shanghai", true, 1},
+				{"ap-guangzhou", false, 1},
+				{"ap-shanghai", false, 1},
+			},
+		},
+		{
+			name: "delete batch size split",
+			regionDiffs: []LoadBalancerRegionDiff{
+				{Region: "ap-guangzhou", Delete: makeBriefs("lb-1", "lb-2", "lb-3", "lb-4", "lb-5")},
+			},
+			wantBatches: []struct {
+				region   string
+				isDelete bool
+				count    int
+			}{
+				{"ap-guangzhou", true, 2},
+				{"ap-guangzhou", true, 2},
+				{"ap-guangzhou", true, 1},
+			},
+		},
+		{
+			name: "upsert batch size split",
+			regionDiffs: []LoadBalancerRegionDiff{
+				{Region: "ap-guangzhou", Create: makeBriefs("lb-1", "lb-2", "lb-3", "lb-4", "lb-5", "lb-6", "lb-7")},
+			},
+			wantBatches: []struct {
+				region   string
+				isDelete bool
+				count    int
+			}{
+				{"ap-guangzhou", false, 3},
+				{"ap-guangzhou", false, 3},
+				{"ap-guangzhou", false, 1},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			batches := executor.buildBatches(tt.regionDiffs)
+
+			if tt.wantBatches == nil {
+				require.Empty(t, batches)
+				return
+			}
+
+			require.Len(t, batches, len(tt.wantBatches))
+			for i, want := range tt.wantBatches {
+				require.Equal(t, want.region, batches[i].region)
+				require.Equal(t, want.isDelete, batches[i].isDelete)
+				require.Len(t, batches[i].details, want.count)
+			}
+		})
+	}
+}
+
+func TestBuildBatchesLargeUpsert(t *testing.T) {
+	// 阈值 4：清理批 2 条一批，同步数量未超阈值时 3 条一批，超过阈值后 5 条一批
+	setClbCondSyncLargeConfig(2, 3, 4, 5)
+
+	executor := &CondSyncLoadBalancerExecutor{opt: &CondSyncLoadBalancerOption{
+		Vendor:    enumor.TCloud,
+		AccountID: "acc-1",
+	}}
+
+	// 同步数量等于阈值，仍按常规批次大小拆分
+	batches := executor.buildBatches([]LoadBalancerRegionDiff{
+		{Region: "ap-guangzhou", Create: makeBriefs("lb-1", "lb-2"), Update: makeBriefs("lb-3", "lb-4")},
+	})
+	require.Len(t, batches, 2)
+	require.Len(t, batches[0].details, 3)
+	require.Len(t, batches[1].details, 1)
+
+	// 多地域同步数量之和超过阈值，各地域均改用大批次大小
+	batches = executor.buildBatches([]LoadBalancerRegionDiff{
+		{Region: "ap-guangzhou", Create: makeBriefs("lb-1", "lb-2", "lb-3")},
+		{Region: "ap-shanghai", Update: makeBriefs("lb-4", "lb-5", "lb-6")},
+	})
+	require.Len(t, batches, 2)
+	require.Equal(t, "ap-guangzhou", batches[0].region)
+	require.Len(t, batches[0].details, 3)
+	require.Equal(t, "ap-shanghai", batches[1].region)
+	require.Len(t, batches[1].details, 3)
+
+	// 清理批次不受同步数量阈值影响
+	batches = executor.buildBatches([]LoadBalancerRegionDiff{
+		{Region: "ap-guangzhou", Delete: makeBriefs("lb-d1", "lb-d2", "lb-d3"),
+			Create: makeBriefs("lb-1", "lb-2", "lb-3", "lb-4", "lb-5")},
+	})
+	require.Len(t, batches, 3)
+	require.True(t, batches[0].isDelete)
+	require.Len(t, batches[0].details, 2)
+	require.True(t, batches[1].isDelete)
+	require.Len(t, batches[1].details, 1)
+	require.False(t, batches[2].isDelete)
+	require.Len(t, batches[2].details, 5)
+}
+
+func TestCondSyncLoadBalancerOptionBkBizID(t *testing.T) {
+	tests := []struct {
+		name string
+		opt  *CondSyncLoadBalancerOption
+		want int64
+	}{
+		{name: "nil option", opt: nil, want: constant.UnassignedBiz},
+		{name: "nil bk_biz_id", opt: &CondSyncLoadBalancerOption{}, want: constant.UnassignedBiz},
+		{name: "biz entry", opt: &CondSyncLoadBalancerOption{BkBizID: 213}, want: 213},
+		{name: "unassigned", opt: &CondSyncLoadBalancerOption{BkBizID: constant.UnassignedBiz},
+			want: constant.UnassignedBiz},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, tt.opt.bkBizID())
+		})
+	}
+}
+
+func TestNewTaskDetails(t *testing.T) {
+	opt := &CondSyncLoadBalancerOption{
+		AccountID: "acc-1",
+		BkBizID:   213,
+	}
+	executor := &CondSyncLoadBalancerExecutor{opt: opt, bkBizID: opt.bkBizID()}
+	briefs := []corelb.LoadBalancerBrief{
+		{CloudID: "lb-1", Region: "ap-nanjing", Address: "1.1.1.1", Domain: "lb.example.com"},
+	}
+
+	details := executor.newTaskDetails(enumor.CondSyncLbOpUpdate, briefs)
+	require.Len(t, details, 1)
+	require.Equal(t, enumor.CondSyncLbOpUpdate, details[0].param.Op)
+	require.Equal(t, "acc-1", details[0].param.AccountID)
+	require.Equal(t, "lb-1", details[0].param.CloudLbID)
+	require.Equal(t, "ap-nanjing", details[0].param.Region)
+	require.Equal(t, "1.1.1.1", details[0].param.ClbVipDomain)
+	require.Equal(t, "lb.example.com", details[0].param.Domain)
+	require.Equal(t, int64(213), executor.bkBizID)
+
+	raw, err := json.Marshal(details[0].param)
+	require.NoError(t, err)
+	require.Contains(t, string(raw), `"op"`)
+	require.Contains(t, string(raw), `"account_id"`)
+	require.Contains(t, string(raw), `"cloud_lb_id"`)
+	require.Contains(t, string(raw), `"clb_vip_domain"`)
+	require.Contains(t, string(raw), `"domain"`)
+	require.NotContains(t, string(raw), `"cloud_id"`)
+	require.NotContains(t, string(raw), `"bk_biz_id"`)
+	require.NotContains(t, string(raw), " / ")
+}
+
+func TestNewTaskDetailsVipFallback(t *testing.T) {
+	executor := &CondSyncLoadBalancerExecutor{opt: &CondSyncLoadBalancerOption{AccountID: "acc-1"}}
+
+	ipv6Details := executor.newTaskDetails(enumor.CondSyncLbOpCreate, []corelb.LoadBalancerBrief{
+		{CloudID: "lb-v6", AddressIPv6: "::1"},
+	})
+	require.Equal(t, "::1", ipv6Details[0].param.ClbVipDomain)
+	require.Empty(t, ipv6Details[0].param.Domain)
+}
+
+func TestBuildFlowTasks(t *testing.T) {
+	setClbCondSyncConfig(2, 3)
+
+	opt := &CondSyncLoadBalancerOption{
+		Vendor:    enumor.TCloud,
+		AccountID: "acc-1",
+	}
+	executor := &CondSyncLoadBalancerExecutor{opt: opt}
+
+	regionDiffs := []LoadBalancerRegionDiff{
+		{Region: "ap-guangzhou", Delete: makeBriefs("lb-d1", "lb-d2"), Create: makeBriefs("lb-c1")},
+	}
+	executor.batches = executor.buildBatches(regionDiffs)
+
+	// Simulate taskDetailID assignment after createTaskDetails
+	for _, batch := range executor.batches {
+		for i, detail := range batch.details {
+			detail.taskDetailID = "detail-" + detail.param.CloudLbID
+			_ = i
+		}
+	}
+
+	flowTasks := executor.buildFlowTasks()
+
+	require.Len(t, flowTasks, 2)
+
+	// First task: delete, no DependOn
+	require.Equal(t, enumor.ActionBatchTaskSyncLbDelete, flowTasks[0].ActionName)
+	require.Empty(t, flowTasks[0].DependOn)
+
+	// Second task: upsert, depends on first
+	require.Equal(t, enumor.ActionBatchTaskSyncLbUpsert, flowTasks[1].ActionName)
+	require.Len(t, flowTasks[1].DependOn, 1)
+	require.Equal(t, flowTasks[0].ActionID, flowTasks[1].DependOn[0])
+
+	// Verify params
+	deleteParams, ok := flowTasks[0].Params.(*actionlb.BatchTaskSyncLbDeleteOption)
+	require.True(t, ok)
+	require.Equal(t, "ap-guangzhou", deleteParams.Region)
+	require.Equal(t, []string{"lb-d1", "lb-d2"}, deleteParams.CloudIDs)
+	require.Len(t, deleteParams.ManagementDetailIDs, 2)
+
+	upsertParams, ok := flowTasks[1].Params.(*actionlb.BatchTaskSyncLbUpsertOption)
+	require.True(t, ok)
+	require.Equal(t, "ap-guangzhou", upsertParams.Region)
+	require.Equal(t, []string{"lb-c1"}, upsertParams.CloudIDs)
+	require.Len(t, upsertParams.ManagementDetailIDs, 1)
+}
+
+func TestBuildFlowTasksEmpty(t *testing.T) {
+	setClbCondSyncConfig(2, 3)
+
+	opt := &CondSyncLoadBalancerOption{
+		Vendor:    enumor.TCloud,
+		AccountID: "acc-1",
+	}
+	executor := &CondSyncLoadBalancerExecutor{opt: opt}
+	executor.batches = executor.buildBatches(nil)
+
+	flowTasks := executor.buildFlowTasks()
+	require.Empty(t, flowTasks)
+}
+
+func makeBriefs(cloudIDs ...string) []corelb.LoadBalancerBrief {
+	briefs := make([]corelb.LoadBalancerBrief, 0, len(cloudIDs))
+	for _, id := range cloudIDs {
+		briefs = append(briefs, corelb.LoadBalancerBrief{CloudID: id})
+	}
+	return briefs
+}
+
+// stubTaskManagementLister stubs taskManagementLister for testing.
+type stubTaskManagementLister struct {
+	resp *task.ListManagementResult
+	err  error
+}
+
+func (s *stubTaskManagementLister) List(kt *kit.Kit, req *core.ListReq) (*task.ListManagementResult, error) {
+	return s.resp, s.err
+}
+
+// stubFlowLister stubs flowLister for testing.
+type stubFlowLister struct {
+	resp *ts.ListFlowResult
+	err  error
+}
+
+func (s *stubFlowLister) ListFlow(kt *kit.Kit, req *core.ListReq) (*ts.ListFlowResult, error) {
+	return s.resp, s.err
+}
+
+func TestCheckRunningCondSyncTask(t *testing.T) {
+	kt := kit.New()
+
+	tests := []struct {
+		name        string
+		opt         *CondSyncLoadBalancerOption
+		mgmtResp    *task.ListManagementResult
+		mgmtErr     error
+		flowResp    *ts.ListFlowResult
+		flowErr     error
+		wantErr     bool
+		wantErrCode int32
+	}{
+		{
+			name: "no running management, allow",
+			opt: &CondSyncLoadBalancerOption{
+				Vendor:    enumor.TCloud,
+				AccountID: "acc-1",
+			},
+			mgmtResp: &task.ListManagementResult{Details: []coretask.Management{}},
+			wantErr:  false,
+		},
+		{
+			name: "running management with empty flow_ids, allow",
+			opt: &CondSyncLoadBalancerOption{
+				Vendor:    enumor.TCloud,
+				AccountID: "acc-1",
+			},
+			mgmtResp: &task.ListManagementResult{Details: []coretask.Management{
+				{ID: "task-1", FlowIDs: []string{}},
+			}},
+			wantErr: false,
+		},
+		{
+			name: "running management with all terminal flows, allow",
+			opt: &CondSyncLoadBalancerOption{
+				Vendor:    enumor.TCloud,
+				AccountID: "acc-1",
+			},
+			mgmtResp: &task.ListManagementResult{Details: []coretask.Management{
+				{ID: "task-1", FlowIDs: []string{"flow-1", "flow-2"}},
+			}},
+			flowResp: &ts.ListFlowResult{Details: []coreasync.AsyncFlow{
+				{ID: "flow-1", State: enumor.FlowSuccess},
+				{ID: "flow-2", State: enumor.FlowFailed},
+			}},
+			wantErr: false,
+		},
+		{
+			name: "running management with non-terminal flow, reject",
+			opt: &CondSyncLoadBalancerOption{
+				Vendor:    enumor.TCloud,
+				AccountID: "acc-1",
+			},
+			mgmtResp: &task.ListManagementResult{Details: []coretask.Management{
+				{ID: "task-1", FlowIDs: []string{"flow-1"}},
+			}},
+			flowResp: &ts.ListFlowResult{Details: []coreasync.AsyncFlow{
+				{ID: "flow-1", State: enumor.FlowRunning},
+			}},
+			wantErr:     true,
+			wantErrCode: errf.TooManyRequest,
+		},
+		{
+			name: "management list error",
+			opt: &CondSyncLoadBalancerOption{
+				Vendor:    enumor.TCloud,
+				AccountID: "acc-1",
+			},
+			mgmtErr: errors.New("db error"),
+			wantErr: true,
+		},
+		{
+			name: "flow list error",
+			opt: &CondSyncLoadBalancerOption{
+				Vendor:    enumor.TCloud,
+				AccountID: "acc-1",
+			},
+			mgmtResp: &task.ListManagementResult{Details: []coretask.Management{
+				{ID: "task-1", FlowIDs: []string{"flow-1"}},
+			}},
+			flowErr: errors.New("task server error"),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mgmtCli := &stubTaskManagementLister{resp: tt.mgmtResp, err: tt.mgmtErr}
+			flowCli := &stubFlowLister{resp: tt.flowResp, err: tt.flowErr}
+
+			err := CheckRunningCondSyncTask(kt, mgmtCli, flowCli, tt.opt)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.wantErrCode != 0 {
+					ef := errf.Error(err)
+					require.NotNil(t, ef)
+					require.Equal(t, tt.wantErrCode, ef.Code)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/cmd/cloud-server/logics/load-balancer/cond_sync_test.go
+++ b/cmd/cloud-server/logics/load-balancer/cond_sync_test.go
@@ -1,0 +1,137 @@
+/*
+ * TencentBlueKing is pleased to support the open source community by making
+ * 蓝鲸智云 - 混合云管理平台 (BlueKing - Hybrid Cloud Management System) available.
+ * Copyright (C) 2024 THL A29 Limited,
+ * a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * We undertake not to change the open source license (MIT license) applicable
+ * to the current version of the project delivered to anyone in the future.
+ */
+
+package lblogic
+
+import (
+	"testing"
+
+	corelb "hcm/pkg/api/core/cloud/load-balancer"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiffLoadBalancerBrief(t *testing.T) {
+	region := "ap-guangzhou"
+
+	tests := []struct {
+		name       string
+		cloudLBs   []corelb.LoadBalancerBrief
+		dbLBs      []corelb.LoadBalancerBrief
+		wantCreate []string
+		wantUpdate []string
+		wantDelete []string
+	}{
+		{
+			name:       "empty input",
+			cloudLBs:   nil,
+			dbLBs:      nil,
+			wantCreate: nil,
+			wantUpdate: nil,
+			wantDelete: nil,
+		},
+		{
+			name: "cloud only, all create",
+			cloudLBs: []corelb.LoadBalancerBrief{
+				{CloudID: "lb-1"}, {CloudID: "lb-2"},
+			},
+			dbLBs:      nil,
+			wantCreate: []string{"lb-1", "lb-2"},
+			wantUpdate: nil,
+			wantDelete: nil,
+		},
+		{
+			name:     "db only, all delete",
+			cloudLBs: nil,
+			dbLBs: []corelb.LoadBalancerBrief{
+				{CloudID: "lb-1"}, {CloudID: "lb-2"},
+			},
+			wantCreate: nil,
+			wantUpdate: nil,
+			wantDelete: []string{"lb-1", "lb-2"},
+		},
+		{
+			name: "both exist, all update",
+			cloudLBs: []corelb.LoadBalancerBrief{
+				{CloudID: "lb-1"}, {CloudID: "lb-2"},
+			},
+			dbLBs: []corelb.LoadBalancerBrief{
+				{CloudID: "lb-1"}, {CloudID: "lb-2"},
+			},
+			wantCreate: nil,
+			wantUpdate: []string{"lb-1", "lb-2"},
+			wantDelete: nil,
+		},
+		{
+			name: "mixed create update delete",
+			cloudLBs: []corelb.LoadBalancerBrief{
+				{CloudID: "lb-create"}, {CloudID: "lb-update"},
+			},
+			dbLBs: []corelb.LoadBalancerBrief{
+				{CloudID: "lb-update"}, {CloudID: "lb-delete"},
+			},
+			wantCreate: []string{"lb-create"},
+			wantUpdate: []string{"lb-update"},
+			wantDelete: []string{"lb-delete"},
+		},
+		{
+			name: "cloud duplicate cloud_id deduplicated",
+			cloudLBs: []corelb.LoadBalancerBrief{
+				{CloudID: "lb-1"}, {CloudID: "lb-1"}, {CloudID: "lb-2"},
+			},
+			dbLBs:      nil,
+			wantCreate: []string{"lb-1", "lb-2"},
+			wantUpdate: nil,
+			wantDelete: nil,
+		},
+		{
+			name: "cloud duplicate with db match still update once",
+			cloudLBs: []corelb.LoadBalancerBrief{
+				{CloudID: "lb-1"}, {CloudID: "lb-1"},
+			},
+			dbLBs: []corelb.LoadBalancerBrief{
+				{CloudID: "lb-1"},
+			},
+			wantCreate: nil,
+			wantUpdate: []string{"lb-1"},
+			wantDelete: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			diff := DiffLoadBalancerBrief(region, tt.cloudLBs, tt.dbLBs)
+
+			require.Equal(t, region, diff.Region)
+			require.Equal(t, tt.wantCreate, extractCloudIDs(diff.Create))
+			require.Equal(t, tt.wantUpdate, extractCloudIDs(diff.Update))
+			require.Equal(t, tt.wantDelete, extractCloudIDs(diff.Delete))
+		})
+	}
+}
+
+func extractCloudIDs(briefs []corelb.LoadBalancerBrief) []string {
+	if len(briefs) == 0 {
+		return nil
+	}
+	ids := make([]string, 0, len(briefs))
+	for _, b := range briefs {
+		ids = append(ids, b.CloudID)
+	}
+	return ids
+}

--- a/cmd/cloud-server/logics/load-balancer/query.go
+++ b/cmd/cloud-server/logics/load-balancer/query.go
@@ -24,11 +24,18 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
+	typecore "hcm/pkg/adaptor/types/core"
+	typeslb "hcm/pkg/adaptor/types/load-balancer"
 	"hcm/pkg/api/core"
 	corecvm "hcm/pkg/api/core/cloud/cvm"
 	corelb "hcm/pkg/api/core/cloud/load-balancer"
+	hcproto "hcm/pkg/api/hc-service/load-balancer"
+	"hcm/pkg/cc"
+	"hcm/pkg/client"
 	dataservice "hcm/pkg/client/data-service"
+	"hcm/pkg/criteria/constant"
 	"hcm/pkg/criteria/enumor"
 	"hcm/pkg/criteria/errf"
 	"hcm/pkg/dal/dao/tools"
@@ -38,6 +45,8 @@ import (
 	"hcm/pkg/tools/cidr"
 	"hcm/pkg/tools/converter"
 	"hcm/pkg/tools/slice"
+
+	"golang.org/x/sync/errgroup"
 )
 
 // ListLoadBalancerMap 批量获取负载均衡列表信息
@@ -53,7 +62,7 @@ func ListLoadBalancerMap(kt *kit.Kit, cli *dataservice.Client, lbIDs []string) (
 	}
 	lbList, err := cli.Global.LoadBalancer.ListLoadBalancer(kt, clbReq)
 	if err != nil {
-		logs.Errorf("list load balancer failed, lbIDs: %v, err: %v, rid: %s", lbIDs, err, kt.Rid)
+		logs.Errorf("list load balancer failed, err: %v, count: %d, rid: %s", err, len(lbIDs), kt.Rid)
 		return nil, err
 	}
 
@@ -467,4 +476,252 @@ func parseSnapInfoTCloudLBExtension(kt *kit.Kit, raw json.RawMessage) (
 	targetCloudVpcID = converter.PtrToVal(extension.TargetCloudVpcID)
 	lbTargetRegion = converter.PtrToVal(extension.TargetRegion)
 	return
+}
+
+// -------------------------- 负载均衡简要信息查询 --------------------------
+
+// ListLoadBalancerBriefOption 查询单个地域负载均衡简要信息的条件
+type ListLoadBalancerBriefOption struct {
+	// Vendor 云厂商，当前支持 tcloud
+	Vendor enumor.Vendor
+	// AccountID 账号ID
+	AccountID string
+	// Region 地域，单次查询只处理一个地域
+	Region string
+	// BkBizID 业务ID，为空表示不按业务过滤
+	BkBizID *int64
+	// CloudIDs 云上ID，为空表示查询该地域全部
+	CloudIDs []string
+	// TagFilters 标签过滤条件
+	TagFilters core.MultiValueTagMap
+}
+
+// loadBalancerBriefQuery 单次云上查询的可变参数。
+// 指定云上ID时按云上单次ID上限分批，未指定时按 offset 翻页，两种方式共用同一套并发执行逻辑。
+type loadBalancerBriefQuery struct {
+	// cloudIDs 本次查询的云上ID，为空表示按 offset 翻页
+	cloudIDs []string
+	// offset 本次查询的分页偏移
+	offset uint64
+}
+
+// ListLoadBalancerBriefFromCloud 查询云上单个地域的负载均衡简要信息。
+// 指定云上ID时批次一开始即可确定，按云上单次ID上限分批后并发拉取；
+// 未指定云上ID时云上单页上限100，先查第一页获得 TotalCount，再按 offset 并发拉取剩余页。
+func ListLoadBalancerBriefFromCloud(kt *kit.Kit, cliSet *client.ClientSet, opt *ListLoadBalancerBriefOption) (
+	[]corelb.LoadBalancerBrief, error) {
+
+	if len(opt.CloudIDs) > 0 {
+		idBatches := slice.Split(opt.CloudIDs, constant.TCLBDescribeMax)
+		queries := make([]loadBalancerBriefQuery, 0, len(idBatches))
+		for _, cloudIDs := range idBatches {
+			queries = append(queries, loadBalancerBriefQuery{cloudIDs: cloudIDs})
+		}
+
+		return concurrentListLoadBalancerBrief(kt, cliSet, opt, queries)
+	}
+
+	start := time.Now()
+	firstPage, totalCount, err := listLoadBalancerBriefPage(kt, cliSet, opt, loadBalancerBriefQuery{})
+	if err != nil {
+		logs.Errorf("list load balancer brief from cloud failed, err: %v, account: %s, region: %s, rid: %s",
+			err, opt.AccountID, opt.Region, kt.Rid)
+		return nil, err
+	}
+	if totalCount <= typecore.TCloudQueryLimit {
+		return firstPage, nil
+	}
+
+	pageCount := int((totalCount + typecore.TCloudQueryLimit - 1) / typecore.TCloudQueryLimit)
+	queries := make([]loadBalancerBriefQuery, 0, pageCount-1)
+	for pageIndex := 1; pageIndex < pageCount; pageIndex++ {
+		queries = append(queries, loadBalancerBriefQuery{offset: uint64(typecore.TCloudQueryLimit * pageIndex)})
+	}
+	restPages, err := concurrentListLoadBalancerBrief(kt, cliSet, opt, queries)
+	if err != nil {
+		return nil, err
+	}
+
+	briefs := make([]corelb.LoadBalancerBrief, 0, int(totalCount))
+	briefs = append(briefs, firstPage...)
+	briefs = append(briefs, restPages...)
+
+	logs.Infof("list load balancer brief all pages from cloud success, account: %s, region: %s, total_count: %d, "+
+		"page_count: %d, count: %d, cost: %s, rid: %s",
+		opt.AccountID, opt.Region, totalCount, pageCount, len(briefs), time.Since(start), kt.Rid)
+
+	return briefs, nil
+}
+
+// concurrentListLoadBalancerBrief 并发执行给定的云上查询，并按给定顺序合并结果。
+func concurrentListLoadBalancerBrief(kt *kit.Kit, cliSet *client.ClientSet, opt *ListLoadBalancerBriefOption,
+	queries []loadBalancerBriefQuery) ([]corelb.LoadBalancerBrief, error) {
+
+	clbCondSync := cc.CloudServer().ConcurrentConfig.ClbCondSync
+	listConcurrent := converter.PtrToVal(clbCondSync.ListConcurrent)
+	if listConcurrent <= 0 {
+		listConcurrent = constant.DefaultCondSyncLbListConcurrent
+	}
+
+	start := time.Now()
+	results := make([][]corelb.LoadBalancerBrief, len(queries))
+	eg, _ := errgroup.WithContext(kt.Ctx)
+	eg.SetLimit(listConcurrent)
+	for index, query := range queries {
+		eg.Go(func() error {
+			page, _, err := listLoadBalancerBriefPage(kt, cliSet, opt, query)
+			if err != nil {
+				logs.Errorf("list load balancer brief from cloud failed, err: %v, account: %s, region: %s, "+
+					"offset: %d, cloud_id_count: %d, rid: %s", err, opt.AccountID, opt.Region, query.offset,
+					len(query.cloudIDs), kt.Rid)
+				return err
+			}
+			results[index] = page
+			return nil
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return nil, err
+	}
+
+	briefs := make([]corelb.LoadBalancerBrief, 0, len(queries)*typecore.TCloudQueryLimit)
+	for i := range results {
+		briefs = append(briefs, results[i]...)
+	}
+
+	logs.Infof("concurrent list load balancer brief from cloud success, account: %s, region: %s, query_count: %d, "+
+		"concurrent: %d, count: %d, cost: %s, rid: %s", opt.AccountID, opt.Region, len(queries), listConcurrent,
+		len(briefs), time.Since(start), kt.Rid)
+
+	return briefs, nil
+}
+
+func listLoadBalancerBriefPage(kt *kit.Kit, cliSet *client.ClientSet, opt *ListLoadBalancerBriefOption,
+	query loadBalancerBriefQuery) ([]corelb.LoadBalancerBrief, uint64, error) {
+
+	orderBy := typeslb.TCloudOrderByCreateTime
+	orderType := typeslb.TCloudCLBOrderAscending
+	req := &hcproto.TCloudListOption{
+		AccountID:  opt.AccountID,
+		Region:     opt.Region,
+		CloudIDs:   query.cloudIDs,
+		OrderBy:    &orderBy,
+		OrderType:  &orderType,
+		TagFilters: opt.TagFilters,
+		Page: &typecore.TCloudPage{
+			Offset: query.offset,
+			Limit:  typecore.TCloudQueryLimit,
+		},
+	}
+
+	start := time.Now()
+	var result *hcproto.TCloudListResult
+	var err error
+	switch opt.Vendor {
+	case enumor.TCloud:
+		result, err = cliSet.HCService().TCloud.Clb.ListLoadBalancerWithCount(kt, req)
+	default:
+		return nil, 0, errf.Newf(errf.InvalidParameter, "vendor: %s not support list load balancer brief", opt.Vendor)
+	}
+	if err != nil {
+		return nil, 0, err
+	}
+	if result == nil {
+		return nil, 0, nil
+	}
+
+	briefs := convCloudLoadBalancerBrief(opt.Region, result.Details)
+	logs.Infof("list load balancer brief page from cloud success, account: %s, region: %s, offset: %d, "+
+		"limit: %d, cloud_id_count: %d, count: %d, total_count: %d, cost: %s, rid: %s",
+		opt.AccountID, opt.Region, query.offset, typecore.TCloudQueryLimit, len(query.cloudIDs), len(briefs),
+		result.TotalCount, time.Since(start), kt.Rid)
+
+	return briefs, result.TotalCount, nil
+}
+
+func convCloudLoadBalancerBrief(region string, lbs []typeslb.TCloudClb) []corelb.LoadBalancerBrief {
+	briefs := make([]corelb.LoadBalancerBrief, 0, len(lbs))
+	for _, one := range lbs {
+		if one.LoadBalancer == nil {
+			continue
+		}
+		briefs = append(briefs, corelb.LoadBalancerBrief{
+			CloudID:     converter.PtrToVal(one.LoadBalancerId),
+			Region:      region,
+			Address:     slice.First(converter.PtrToSlice(one.LoadBalancerVips)),
+			AddressIPv6: converter.PtrToVal(one.AddressIPv6),
+			Domain:      converter.PtrToVal(one.LoadBalancerDomain),
+		})
+	}
+
+	return briefs
+}
+
+// ListLoadBalancerBriefFromDB 查询DB中单个地域的负载均衡简要信息
+func ListLoadBalancerBriefFromDB(kt *kit.Kit, cli *dataservice.Client, opt *ListLoadBalancerBriefOption) (
+	[]corelb.LoadBalancerBrief, error) {
+
+	rules := []*filter.AtomRule{
+		tools.RuleEqual("vendor", opt.Vendor),
+		tools.RuleEqual("account_id", opt.AccountID),
+		tools.RuleEqual("region", opt.Region),
+	}
+	if opt.BkBizID != nil {
+		rules = append(rules, tools.RuleEqual("bk_biz_id", *opt.BkBizID))
+	}
+	if len(opt.CloudIDs) > 0 {
+		rules = append(rules, tools.RuleIn("cloud_id", opt.CloudIDs))
+	}
+	for k := range opt.TagFilters {
+		rules = append(rules, tools.RuleJsonIn("tags."+k, opt.TagFilters[k]))
+	}
+
+	req := &core.ListReq{
+		Filter: tools.ExpressionAnd(rules...),
+		Fields: corelb.LoadBalancerBriefFields,
+		Page:   &core.BasePage{Start: 0, Limit: core.DefaultMaxPageLimit},
+	}
+
+	briefs := make([]corelb.LoadBalancerBrief, 0)
+	for {
+		result, err := cli.Global.LoadBalancer.ListLoadBalancer(kt, req)
+		if err != nil {
+			logs.Errorf("list load balancer brief from db failed, err: %v, account: %s, region: %s, "+
+				"cloud_id_count: %d, rid: %s", err, opt.AccountID, opt.Region, len(opt.CloudIDs), kt.Rid)
+			return nil, err
+		}
+
+		for _, one := range result.Details {
+			briefs = append(briefs, convDBLoadBalancerBrief(one))
+		}
+
+		if uint(len(result.Details)) < core.DefaultMaxPageLimit {
+			break
+		}
+		req.Page.Start += uint32(core.DefaultMaxPageLimit)
+	}
+
+	return briefs, nil
+}
+
+// convDBLoadBalancerBrief DB中公网、内网地址分开存储，取值规则与云上VIP对齐：优先取公网，没有再取内网
+func convDBLoadBalancerBrief(lb corelb.BaseLoadBalancer) corelb.LoadBalancerBrief {
+	return corelb.LoadBalancerBrief{
+		CloudID:     lb.CloudID,
+		Region:      lb.Region,
+		Address:     firstAddress(lb.PublicIPv4Addresses, lb.PrivateIPv4Addresses),
+		AddressIPv6: firstAddress(lb.PublicIPv6Addresses, lb.PrivateIPv6Addresses),
+		Domain:      lb.Domain,
+	}
+}
+
+func firstAddress(publicAddresses, privateAddresses []string) string {
+	if len(publicAddresses) > 0 {
+		return publicAddresses[0]
+	}
+	if len(privateAddresses) > 0 {
+		return privateAddresses[0]
+	}
+
+	return ""
 }

--- a/cmd/cloud-server/service/account/sync.go
+++ b/cmd/cloud-server/service/account/sync.go
@@ -92,7 +92,7 @@ func (a *accountSvc) SyncCloudResourceByCond(cts *rest.Contexts) (any, error) {
 
 	switch vendor {
 	case enumor.TCloud:
-		return a.tcloudCondSyncRes(cts, accountID, resName)
+		return a.tcloudCondSyncRes(cts, accountID, constant.UnassignedBiz, resName)
 	case enumor.HuaWei:
 		return a.huaweiCondSyncRes(cts, accountID, resName)
 	case enumor.Aws:
@@ -158,7 +158,7 @@ func (a *accountSvc) SyncBizCloudResourceByCond(cts *rest.Contexts) (any, error)
 
 	switch vendor {
 	case enumor.TCloud:
-		return a.tcloudCondSyncRes(cts, accountID, resName)
+		return a.tcloudCondSyncRes(cts, accountID, bkBizId, resName)
 	case enumor.HuaWei:
 		return a.huaweiCondSyncRes(cts, accountID, resName)
 	case enumor.Aws:

--- a/cmd/cloud-server/service/account/sync_tcloud.go
+++ b/cmd/cloud-server/service/account/sync_tcloud.go
@@ -40,12 +40,31 @@ import (
 	"hcm/pkg/tools/slice"
 )
 
-func (a *accountSvc) tcloudCondSyncRes(cts *rest.Contexts, accountID string, resType enumor.CloudResourceType) (
+func (a *accountSvc) tcloudCondSyncRes(cts *rest.Contexts, accountID string, bkBizID int64,
+	resType enumor.CloudResourceType) (
 	any, error) {
 
-	req, syncFunc, err := a.decodeTCloudCondSyncRequest(cts, resType)
+	req, syncRoute, err := a.decodeTCloudCondSyncRequest(cts, resType)
 	if err != nil {
 		return nil, err
+	}
+
+	syncParams := &tcloud.CondSyncParams{
+		AccountID:  accountID,
+		BkBizID:    bkBizID,
+		Regions:    req.Regions,
+		CloudIDs:   req.CloudIDs,
+		TagFilters: req.TagFilters,
+	}
+
+	if syncRoute.HasAsync() {
+		result, err := syncRoute.AsyncFunc(cts.Kit, a.client, syncParams)
+		if err != nil {
+			logs.Errorf("conditional async sync failed, err: %v, vendor: %s, resource: %s, account: %s, "+
+				"req: %+v, rid: %s", err, enumor.TCloud, resType, accountID, req, cts.Kit.Rid)
+			return nil, err
+		}
+		return result, nil
 	}
 
 	resLockKey := lock.Key(accountID)
@@ -72,19 +91,12 @@ func (a *accountSvc) tcloudCondSyncRes(cts *rest.Contexts, accountID string, res
 	}()
 
 	logs.Infof("lock account sync key: %s, resType: %s, rid: %s", resLockKey, resType, cts.Kit.Rid)
-	syncParams := &tcloud.CondSyncParams{
-		AccountID:  accountID,
-		Regions:    req.Regions,
-		CloudIDs:   req.CloudIDs,
-		TagFilters: req.TagFilters,
-	}
-
 	startAt := time.Now()
 	kt := cts.Kit.NewSubKit()
 	// 设置超时控制
 	cancel := kt.CtxWithTimeoutMS(int(AccountSyncDefaultTimeout / time.Millisecond))
 	defer cancel()
-	err = syncFunc(kt, a.client, syncParams)
+	err = syncRoute.SyncFunc(kt, a.client, syncParams)
 	if err != nil {
 		logs.Errorf("[%s] conditional sync failed on resource(%s), err: %v, account: %s, req: %+v, "+
 			"cost: %s, rid: %s", enumor.TCloud, resType, err, accountID, req, time.Since(startAt), cts.Kit.Rid)
@@ -97,7 +109,7 @@ func (a *accountSvc) tcloudCondSyncRes(cts *rest.Contexts, accountID string, res
 }
 
 func (a *accountSvc) decodeTCloudCondSyncRequest(cts *rest.Contexts, resType enumor.CloudResourceType) (
-	*cloudaccount.ResCondSyncReq, tcloud.CondSyncFunc, error) {
+	*cloudaccount.ResCondSyncReq, *tcloud.CondSyncRoute, error) {
 
 	req := new(cloudaccount.ResCondSyncReq)
 	if err := cts.DecodeInto(req); err != nil {
@@ -112,7 +124,7 @@ func (a *accountSvc) decodeTCloudCondSyncRequest(cts *rest.Contexts, resType enu
 		return nil, nil, err
 	}
 
-	syncFunc, ok := tcloud.GetCondSyncFunc(resType)
+	route, ok := tcloud.GetCondSyncRoute(resType)
 	if !ok {
 		return nil, nil, fmt.Errorf("tcloud conditional sync resource does not support %s", resType)
 	}
@@ -144,5 +156,5 @@ func (a *accountSvc) decodeTCloudCondSyncRequest(cts *rest.Contexts, resType enu
 		return nil, nil, errors.New("request regions mismatch regions on db")
 	}
 	req.Regions = slice.Map(regionList, region.TCloudRegion.GetCloudID)
-	return req, syncFunc, nil
+	return req, route, nil
 }

--- a/cmd/cloud-server/service/sync/tcloud/async_cond_sync_resource.go
+++ b/cmd/cloud-server/service/sync/tcloud/async_cond_sync_resource.go
@@ -1,0 +1,103 @@
+/*
+ * TencentBlueKing is pleased to support the open source community by making
+ * 蓝鲸智云 - 混合云管理平台 (BlueKing - Hybrid Cloud Management System) available.
+ * Copyright (C) 2022 THL A29 Limited,
+ * a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * We undertake not to change the open source license (MIT license) applicable
+ *
+ * to the current version of the project delivered to anyone in the future.
+ */
+
+package tcloud
+
+import (
+	lblogic "hcm/cmd/cloud-server/logics/load-balancer"
+	cloudtask "hcm/pkg/api/cloud-server/task"
+	"hcm/pkg/api/core"
+	"hcm/pkg/api/data-service/task"
+	ts "hcm/pkg/api/task-server"
+	"hcm/pkg/client"
+	dataservice "hcm/pkg/client/data-service"
+	taskserver "hcm/pkg/client/task-server"
+	"hcm/pkg/criteria/enumor"
+	"hcm/pkg/kit"
+	"hcm/pkg/logs"
+)
+
+// taskManagementAdapter adapts dataservice.Client to lblogic.taskManagementLister.
+type taskManagementAdapter struct {
+	cli *dataservice.Client
+}
+
+// List 查询 task_management 列表。
+func (a taskManagementAdapter) List(kt *kit.Kit, req *core.ListReq) (*task.ListManagementResult, error) {
+	return a.cli.Global.TaskManagement.List(kt, req)
+}
+
+// flowAdapter adapts taskserver.Client to lblogic.flowLister.
+type flowAdapter struct {
+	cli *taskserver.Client
+}
+
+// ListFlow 查询 flow 列表。
+func (a flowAdapter) ListFlow(kt *kit.Kit, req *core.ListReq) (*ts.ListFlowResult, error) {
+	return a.cli.ListFlow(kt, req)
+}
+
+// AsyncCondSyncLoadBalancer creates an asynchronous CLB conditional sync task.
+func AsyncCondSyncLoadBalancer(kt *kit.Kit, cliSet *client.ClientSet, params *CondSyncParams) (any, error) {
+	opt := &lblogic.CondSyncLoadBalancerOption{
+		Vendor:     enumor.TCloud,
+		AccountID:  params.AccountID,
+		BkBizID:    params.BkBizID,
+		Regions:    params.Regions,
+		CloudIDs:   params.CloudIDs,
+		TagFilters: params.TagFilters,
+	}
+
+	mgmtCli := taskManagementAdapter{cli: cliSet.DataService()}
+	flowCli := flowAdapter{cli: cliSet.TaskServer()}
+	if err := lblogic.CheckRunningCondSyncTask(kt, mgmtCli, flowCli, opt); err != nil {
+		return nil, err
+	}
+
+	regionDiffs := make([]lblogic.LoadBalancerRegionDiff, 0, len(opt.Regions))
+	total := 0
+	for _, region := range opt.Regions {
+		diff, err := lblogic.ListAndDiffLoadBalancerByRegion(kt, cliSet, opt, region)
+		if err != nil {
+			logs.Errorf("[%s] diff conditional sync load balancer failed, err: %v, account: %s, region: %s, rid: %s",
+				enumor.TCloud, err, opt.AccountID, region, kt.Rid)
+			return nil, err
+		}
+		regionDiffs = append(regionDiffs, *diff)
+		total += len(diff.Create) + len(diff.Update) + len(diff.Delete)
+	}
+
+	// total=0 表示请求条件下没有任何可处理的 CLB。
+	// 两侧已有同一批 CLB 时全部进入 update，仍会创建任务。
+	if total == 0 {
+		logs.Infof("[%s] skip create conditional sync load balancer task because no processable load balancer, "+
+			"account: %s, rid: %s",
+			enumor.TCloud, opt.AccountID, kt.Rid)
+		return cloudtask.CreateTaskManagementResp{}, nil
+	}
+
+	taskManagementID, err := lblogic.CreateCondSyncTask(kt, cliSet, opt, regionDiffs)
+	if err != nil {
+		logs.Errorf("[%s] create conditional sync load balancer task failed, err: %v, account: %s, rid: %s",
+			enumor.TCloud, err, opt.AccountID, kt.Rid)
+		return nil, err
+	}
+
+	return cloudtask.CreateTaskManagementResp{TaskManagementID: taskManagementID}, nil
+}

--- a/cmd/cloud-server/service/sync/tcloud/cond_sync_resource.go
+++ b/cmd/cloud-server/service/sync/tcloud/cond_sync_resource.go
@@ -36,11 +36,23 @@ type CondSyncParams struct {
 	Regions   []string `json:"regions,omitempty" validate:"max=20"`
 	CloudIDs  []string `json:"cloud_ids,omitempty" validate:"max=20"`
 
+	BkBizID    int64                 `json:"bk_biz_id,omitempty"`
 	TagFilters core.MultiValueTagMap `json:"tag_filters,omitempty" validate:"max=10"`
 }
 
 // CondSyncFunc sync resource by given condition
 type CondSyncFunc func(kt *kit.Kit, cliSet *client.ClientSet, params *CondSyncParams) error
+
+// CondAsyncFunc asynchronously syncs a resource by the given condition.
+type CondAsyncFunc func(kt *kit.Kit, cliSet *client.ClientSet, params *CondSyncParams) (any, error)
+
+// CondSyncRoute defines the selected conditional sync route.
+type CondSyncRoute struct {
+	// SyncFunc is the synchronous conditional sync function.
+	SyncFunc CondSyncFunc
+	// AsyncFunc is the asynchronous conditional sync function.
+	AsyncFunc CondAsyncFunc
+}
 
 var condSyncFuncMap = map[enumor.CloudResourceType]CondSyncFunc{
 	enumor.RegionCloudResType:             CondSyncRegion,
@@ -51,10 +63,27 @@ var condSyncFuncMap = map[enumor.CloudResourceType]CondSyncFunc{
 	enumor.PermissionTemplateCloudResType: CondSyncPermissionTemplate,
 }
 
-// GetCondSyncFunc ...
-func GetCondSyncFunc(res enumor.CloudResourceType) (syncFunc CondSyncFunc, ok bool) {
-	syncFunc, ok = condSyncFuncMap[res]
-	return syncFunc, ok
+var condAsyncFuncMap = map[enumor.CloudResourceType]CondAsyncFunc{
+	enumor.LoadBalancerCloudResType: AsyncCondSyncLoadBalancer,
+}
+
+// GetCondSyncRoute gets the conditional sync route for a resource.
+func GetCondSyncRoute(res enumor.CloudResourceType) (*CondSyncRoute, bool) {
+	syncFunc, syncOK := condSyncFuncMap[res]
+	asyncFunc, asyncOK := condAsyncFuncMap[res]
+	if !syncOK && !asyncOK {
+		return nil, false
+	}
+
+	return &CondSyncRoute{
+		SyncFunc:  syncFunc,
+		AsyncFunc: asyncFunc,
+	}, true
+}
+
+// HasAsync checks whether the selected route has an asynchronous override.
+func (r *CondSyncRoute) HasAsync() bool {
+	return r != nil && r.AsyncFunc != nil
 }
 
 // CondSyncLoadBalancer ...

--- a/cmd/hc-service/logics/res-sync/tcloud/client.go
+++ b/cmd/hc-service/logics/res-sync/tcloud/client.go
@@ -85,6 +85,7 @@ type Interface interface {
 	RemoveCertDeleteFromCloud(kt *kit.Kit, accountID string, region string) error
 
 	LoadBalancer(kt *kit.Kit, params *SyncBaseParams, opt *SyncLBOption) (*SyncResult, error)
+	BatchDeleteLoadBalancer(kt *kit.Kit, accountID string, region string, delCloudIDs []string) error
 	RemoveLoadBalancerDeleteFromCloud(kt *kit.Kit, params *SyncRemovedParams) error
 
 	// LoadBalancerWithListener 同步负载均衡及监听器

--- a/cmd/hc-service/logics/res-sync/tcloud/load_balancer.go
+++ b/cmd/hc-service/logics/res-sync/tcloud/load_balancer.go
@@ -216,10 +216,22 @@ func (cli *client) RemoveLoadBalancerDeleteFromCloudV2(kt *kit.Kit, params *Sync
 
 	logs.Infof("[%s] will remove %d deleted load balancer from cloud, account: %s, region: %s, rid: %s",
 		enumor.TCloud, len(delCloudIDs), params.AccountID, params.Region, kt.Rid)
+	if err := cli.BatchDeleteLoadBalancer(kt, params.AccountID, params.Region, delCloudIDs); err != nil {
+		logs.Errorf("fail to delete removed clb, err: %v, account: %s, region: %s, cloudIds: %v, rid: %s",
+			err, params.AccountID, params.Region, delCloudIDs, kt.Rid)
+		return err
+	}
+
+	return nil
+}
+
+// BatchDeleteLoadBalancer 按云上ID分批删除负载均衡，每批复用同步删除逻辑
+func (cli *client) BatchDeleteLoadBalancer(kt *kit.Kit, accountID string, region string, delCloudIDs []string) error {
+
 	for _, idBatch := range slice.Split(delCloudIDs, constant.BatchOperationMaxLimit) {
-		if err := cli.deleteLoadBalancer(kt, params.AccountID, params.Region, idBatch); err != nil {
-			logs.Errorf("fail to delete removed clb, err: %v, account: %s, region: %s, cloudIds: %v, rid: %s",
-				err, params.AccountID, params.Region, idBatch, kt.Rid)
+		if err := cli.deleteLoadBalancer(kt, accountID, region, idBatch); err != nil {
+			logs.Errorf("[%s] fail to batch delete lb, err: %v, account: %s, region: %s, cloudIDs: %v, rid: %s",
+				enumor.TCloud, err, accountID, region, idBatch, kt.Rid)
 			return err
 		}
 	}

--- a/cmd/hc-service/service/load-balancer/tcloud.go
+++ b/cmd/hc-service/service/load-balancer/tcloud.go
@@ -51,6 +51,8 @@ func (svc *clbSvc) initTCloudClbService(cap *capability.Capability) {
 	h.Add("InquiryPriceTCloudLB", http.MethodPost,
 		"/vendors/tcloud/load_balancers/prices/inquiry", svc.InquiryPriceTCloudLB)
 	h.Add("ListTCloudClb", http.MethodPost, "/vendors/tcloud/load_balancers/list", svc.ListTCloudClb)
+	h.Add("ListTCloudClbWithCount", http.MethodPost,
+		"/vendors/tcloud/load_balancers/list_with_count", svc.ListTCloudClbWithCount)
 	h.Add("TCloudDescribeResources", http.MethodPost,
 		"/vendors/tcloud/load_balancers/resources/describe", svc.TCloudDescribeResources)
 	h.Add("TCloudUpdateCLB", http.MethodPatch, "/vendors/tcloud/load_balancers/{id}", svc.TCloudUpdateCLB)
@@ -236,22 +238,70 @@ func (svc *clbSvc) ListTCloudClb(cts *rest.Contexts) (interface{}, error) {
 		return nil, err
 	}
 
-	if req.Page.Limit > adcore.TCloudQueryLimit {
-		req.Page.Limit = adcore.TCloudQueryLimit
-	}
+	normalizeTCloudListPage(req)
 	opt := &typelb.TCloudListOption{
-		Region:   req.Region,
-		CloudIDs: req.CloudIDs,
-		Page:     req.Page,
+		Region:     req.Region,
+		CloudIDs:   req.CloudIDs,
+		Page:       req.Page,
+		OrderBy:    req.OrderBy,
+		OrderType:  req.OrderType,
+		TagFilters: req.TagFilters,
 	}
 	result, err := tcloudAdpt.ListLoadBalancer(cts.Kit, opt)
 	if err != nil {
-		logs.Errorf("[%s] list tcloud clb failed, req: %+v, err: %v, rid: %s",
-			enumor.TCloud, req, err, cts.Kit.Rid)
+		logs.Errorf("[%s] list tcloud clb failed, err: %v, account: %s, region: %s, cloud_id_count: %d, rid: %s",
+			enumor.TCloud, err, req.AccountID, req.Region, len(req.CloudIDs), cts.Kit.Rid)
 		return nil, err
 	}
 
 	return result, nil
+}
+
+// ListTCloudClbWithCount list tcloud clb with total count.
+func (svc *clbSvc) ListTCloudClbWithCount(cts *rest.Contexts) (interface{}, error) {
+	req := new(protolb.TCloudListOption)
+	if err := cts.DecodeInto(req); err != nil {
+		return nil, errf.NewFromErr(errf.DecodeRequestFailed, err)
+	}
+
+	if err := req.Validate(); err != nil {
+		return nil, errf.NewFromErr(errf.InvalidParameter, err)
+	}
+
+	tcloudAdpt, err := svc.ad.TCloud(cts.Kit, req.AccountID)
+	if err != nil {
+		return nil, err
+	}
+
+	normalizeTCloudListPage(req)
+	opt := &typelb.TCloudListOption{
+		Region:     req.Region,
+		CloudIDs:   req.CloudIDs,
+		Page:       req.Page,
+		OrderBy:    req.OrderBy,
+		OrderType:  req.OrderType,
+		TagFilters: req.TagFilters,
+	}
+	result, err := tcloudAdpt.ListLoadBalancerWithCount(cts.Kit, opt)
+	if err != nil {
+		logs.Errorf("[%s] list tcloud clb with count failed, err: %v, account: %s, region: %s, "+
+			"cloud_id_count: %d, rid: %s", enumor.TCloud, err, req.AccountID, req.Region, len(req.CloudIDs),
+			cts.Kit.Rid)
+		return nil, err
+	}
+
+	return &protolb.TCloudListResult{Details: result.Details, TotalCount: result.TotalCount}, nil
+}
+
+func normalizeTCloudListPage(req *protolb.TCloudListOption) {
+	if req.Page == nil {
+		req.Page = &adcore.TCloudPage{Limit: adcore.TCloudQueryLimit}
+		return
+	}
+
+	if req.Page.Limit > adcore.TCloudQueryLimit {
+		req.Page.Limit = adcore.TCloudQueryLimit
+	}
 }
 
 // TCloudDescribeResources 查询clb地域下可用资源

--- a/cmd/hc-service/service/sync/handler/handler.go
+++ b/cmd/hc-service/service/sync/handler/handler.go
@@ -173,7 +173,7 @@ func ResourceSyncV2[T common.CloudResType](cts *rest.Contexts, handler HandlerV2
 	logs.Infof("[ResourceSyncV2] %s remove deleted done, rid: %s", handler.Describe(), kt.Rid)
 
 	// 4. 同步实例详情
-	success, failed, errs := syncResourcesDetail(kt, handler, total, allInstanceList)
+	success, failed, errs := SyncResourcesDetail(kt, handler, total, allInstanceList)
 	cost := time.Since(startedAt)
 	logs.Infof("[ResourceSyncV2] %s sync done, total/success/failed: %d/%d/%d, avg: %.2f res/s, cost: %s, rid: %s",
 		handler.Describe(), total, success, failed, float64(total)/cost.Seconds(), cost, kt.Rid)
@@ -183,7 +183,8 @@ func ResourceSyncV2[T common.CloudResType](cts *rest.Contexts, handler HandlerV2
 	return nil
 }
 
-func syncResourcesDetail[T common.CloudResType](kt *kit.Kit, handler HandlerV2[T], total int, allInstances [][]T) (
+// SyncResourcesDetail 并发同步资源实例详情，倒序下发批次以保证新建实例先同步，返回成功与失败数量。
+func SyncResourcesDetail[T common.CloudResType](kt *kit.Kit, handler HandlerV2[T], total int, allInstances [][]T) (
 	success int, failed int, err error) {
 
 	// 并发同步资源实例

--- a/cmd/hc-service/service/sync/tcloud/load_balancer.go
+++ b/cmd/hc-service/service/sync/tcloud/load_balancer.go
@@ -21,12 +21,16 @@ package tcloud
 
 import (
 	"sync"
+	"time"
 
 	"hcm/cmd/hc-service/logics/res-sync/tcloud"
 	"hcm/cmd/hc-service/service/sync/handler"
 	typecore "hcm/pkg/adaptor/types/core"
 	typeclb "hcm/pkg/adaptor/types/load-balancer"
+	hcsync "hcm/pkg/api/hc-service/sync"
+	"hcm/pkg/criteria/constant"
 	"hcm/pkg/criteria/enumor"
+	"hcm/pkg/criteria/errf"
 	"hcm/pkg/kit"
 	"hcm/pkg/logs"
 	"hcm/pkg/rest"
@@ -47,10 +51,113 @@ func (svc *service) SyncLoadBalancer(cts *rest.Contexts) (interface{}, error) {
 	return nil, handler.ResourceSyncV2(cts, hd)
 }
 
+// DeleteLoadBalancerByCond 按条件删除负载均衡接口
+func (svc *service) DeleteLoadBalancerByCond(cts *rest.Contexts) (interface{}, error) {
+	hd := &lbHandler{
+		baseHandler: baseHandler{
+			resType: enumor.LoadBalancerCloudResType,
+			cli:     svc.syncCli,
+		},
+	}
+	return hd.DeleteLoadBalancerByCond(cts)
+}
+
+// SyncLoadBalancerByCond 按条件同步负载均衡接口
+func (svc *service) SyncLoadBalancerByCond(cts *rest.Contexts) (interface{}, error) {
+	hd := &lbHandler{
+		baseHandler: baseHandler{
+			resType: enumor.LoadBalancerCloudResType,
+			cli:     svc.syncCli,
+		},
+	}
+	return hd.SyncLoadBalancerByCond(cts)
+}
+
 // lbHandler lb sync handler.
 type lbHandler struct {
 	baseHandler
 	offset uint64
+}
+
+// DeleteLoadBalancerByCond 按条件删除负载均衡
+func (hd *lbHandler) DeleteLoadBalancerByCond(cts *rest.Contexts) (interface{}, error) {
+	req := new(hcsync.TCloudDelLoadBalancerByCondReq)
+	if err := cts.DecodeInto(req); err != nil {
+		return nil, errf.NewFromErr(errf.DecodeRequestFailed, err)
+	}
+	if err := req.Validate(); err != nil {
+		return nil, errf.NewFromErr(errf.InvalidParameter, err)
+	}
+
+	syncCli, err := hd.cli.TCloud(cts.Kit, req.AccountID)
+	if err != nil {
+		logs.Errorf("init tcloud sync client failed, err: %v, account: %s, rid: %s", err, req.AccountID, cts.Kit.Rid)
+		return nil, err
+	}
+
+	startedAt := time.Now()
+	if err = syncCli.BatchDeleteLoadBalancer(cts.Kit, req.AccountID, req.Region, req.CloudIDs); err != nil {
+		logs.Errorf("delete load balancer by condition failed, err: %v, account: %s, region: %s, "+
+			"count: %d, rid: %s", err, req.AccountID, req.Region, len(req.CloudIDs), cts.Kit.Rid)
+		return nil, err
+	}
+	logs.Infof("delete load balancer by condition success, account: %s, region: %s, count: %d, cost: %s, rid: %s",
+		req.AccountID, req.Region, len(req.CloudIDs), time.Since(startedAt), cts.Kit.Rid)
+
+	return nil, nil
+}
+
+// SyncLoadBalancerByCond 按条件同步负载均衡，只同步指定云上ID的实例，不做DB全量清理
+func (hd *lbHandler) SyncLoadBalancerByCond(cts *rest.Contexts) (interface{}, error) {
+	req := new(hcsync.TCloudSyncLoadBalancerByCondReq)
+	if err := cts.DecodeInto(req); err != nil {
+		return nil, errf.NewFromErr(errf.DecodeRequestFailed, err)
+	}
+	if err := req.Validate(); err != nil {
+		return nil, errf.NewFromErr(errf.InvalidParameter, err)
+	}
+
+	syncCli, err := hd.cli.TCloud(cts.Kit, req.AccountID)
+	if err != nil {
+		logs.Errorf("init tcloud sync client failed, err: %v, account: %s, rid: %s", err, req.AccountID, cts.Kit.Rid)
+		return nil, err
+	}
+	hd.syncCli = syncCli
+	hd.request = &hcsync.TCloudSyncReq{
+		AccountID:  req.AccountID,
+		Region:     req.Region,
+		TagFilters: req.TagFilters,
+	}
+
+	listStartedAt := time.Now()
+	instances, err := hd.listLoadBalancerByCloudIDs(cts.Kit, req.CloudIDs)
+	if err != nil {
+		logs.Errorf("list load balancer by cloud ids failed, err: %v, account: %s, region: %s, "+
+			"count: %d, rid: %s", err, req.AccountID, req.Region, len(req.CloudIDs), cts.Kit.Rid)
+		return nil, err
+	}
+	logs.Infof("list load balancer by cloud ids done, account: %s, region: %s, count: %d, found: %d, "+
+		"cost: %s, rid: %s", req.AccountID, req.Region, len(req.CloudIDs), len(instances),
+		time.Since(listStartedAt), cts.Kit.Rid)
+	if len(instances) == 0 {
+		// 云上已不存在的实例由删除动作负责清理，此处直接跳过
+		logs.Infof("no load balancer found on cloud, account: %s, region: %s, count: %d, rid: %s",
+			req.AccountID, req.Region, len(req.CloudIDs), cts.Kit.Rid)
+		return nil, nil
+	}
+
+	// 按单次同步上限切分，保持与全量同步一致的下发粒度，避免每批都被当作最后一批再按并发拆细
+	allInstances := slice.Split(instances, constant.CloudResourceSyncMaxLimit)
+	syncStartedAt := time.Now()
+	if _, _, err = handler.SyncResourcesDetail(cts.Kit, hd, len(instances), allInstances); err != nil {
+		logs.Errorf("sync load balancer detail failed, err: %v, account: %s, region: %s, count: %d, rid: %s",
+			err, req.AccountID, req.Region, len(instances), cts.Kit.Rid)
+		return nil, err
+	}
+	logs.Infof("sync load balancer by condition success, account: %s, region: %s, count: %d, cost: %s, rid: %s",
+		req.AccountID, req.Region, len(instances), time.Since(syncStartedAt), cts.Kit.Rid)
+
+	return nil, nil
 }
 
 var _ handler.HandlerV2[typeclb.TCloudClb] = new(lbHandler)
@@ -60,55 +167,10 @@ func (hd *lbHandler) Next(kt *kit.Kit) ([]typeclb.TCloudClb, error) {
 
 	if len(hd.request.CloudIDs) > 0 {
 		// 指定id只处理一次
-		listOpt := &typeclb.TCloudListOption{
-			Region:   hd.request.Region,
-			CloudIDs: hd.request.CloudIDs,
-			Page: &typecore.TCloudPage{
-				Limit: typecore.TCloudQueryLimit,
-			},
-			OrderType:  cvt.ValToPtr(typeclb.TCloudCLBOrderAscending),
-			OrderBy:    cvt.ValToPtr(typeclb.TCloudOrderByCreateTime),
-			TagFilters: hd.request.TagFilters,
-		}
-		lbResult, err := hd.syncCli.CloudCli().ListLoadBalancer(kt, listOpt)
-		if err != nil {
-			logs.Errorf("request adaptor list tcloud load balancer failed, err: %v, opt: %+v, rid: %s",
-				err, listOpt, kt.Rid)
-			return nil, err
-		}
-		return lbResult, nil
+		return hd.listLoadBalancerByCloudIDs(kt, hd.request.CloudIDs)
 	}
 
-	var eg, _ = errgroup.WithContext(kt.Ctx)
-	mu := &sync.Mutex{}
-	results := make([]typeclb.TCloudClb, 0, typecore.TCloudQueryLimit*hd.SyncConcurrent())
-	for i := uint(0); i < hd.SyncConcurrent(); i++ {
-		offset := hd.offset + uint64(typecore.TCloudQueryLimit*i)
-		eg.Go(func() error {
-			listOpt := &typeclb.TCloudListOption{
-				Region: hd.request.Region,
-				Page: &typecore.TCloudPage{
-					Offset: offset,
-					Limit:  typecore.TCloudQueryLimit,
-				},
-				OrderType:  cvt.ValToPtr(typeclb.TCloudCLBOrderAscending),
-				OrderBy:    cvt.ValToPtr(typeclb.TCloudOrderByCreateTime),
-				TagFilters: hd.request.TagFilters,
-			}
-			lbResult, err := hd.syncCli.CloudCli().ListLoadBalancer(kt, listOpt)
-			if err != nil {
-				logs.Errorf("request adaptor list tcloud load balancer failed, err: %v, opt: %+v, rid: %s",
-					err, listOpt, kt.Rid)
-				return err
-			}
-			mu.Lock()
-			results = append(results, lbResult...)
-			mu.Unlock()
-			return nil
-		})
-
-	}
-	err := eg.Wait()
+	results, err := hd.concurrentListLoadBalancer(kt, hd.buildPageListOpts())
 	if err != nil {
 		return nil, err
 	}
@@ -117,6 +179,78 @@ func (hd *lbHandler) Next(kt *kit.Kit) ([]typeclb.TCloudClb, error) {
 		return nil, nil
 	}
 	hd.offset += uint64(len(results))
+	return results, nil
+}
+
+// buildListOpt 构造云上负载均衡查询参数，分页查询与指定ID查询共用
+func (hd *lbHandler) buildListOpt(page *typecore.TCloudPage, cloudIDs []string) *typeclb.TCloudListOption {
+
+	return &typeclb.TCloudListOption{
+		Region:     hd.request.Region,
+		CloudIDs:   cloudIDs,
+		Page:       page,
+		OrderType:  cvt.ValToPtr(typeclb.TCloudCLBOrderAscending),
+		OrderBy:    cvt.ValToPtr(typeclb.TCloudOrderByCreateTime),
+		TagFilters: hd.request.TagFilters,
+	}
+}
+
+// buildPageListOpts 构造本轮分页查询参数，从当前游标开始，每个并发取一页
+func (hd *lbHandler) buildPageListOpts() []*typeclb.TCloudListOption {
+
+	concurrent := hd.SyncConcurrent()
+	opts := make([]*typeclb.TCloudListOption, 0, concurrent)
+	for i := uint(0); i < concurrent; i++ {
+		page := &typecore.TCloudPage{
+			Offset: hd.offset + uint64(typecore.TCloudQueryLimit*i),
+			Limit:  typecore.TCloudQueryLimit,
+		}
+		opts = append(opts, hd.buildListOpt(page, nil))
+	}
+
+	return opts
+}
+
+// listLoadBalancerByCloudIDs 按云上ID拉取负载均衡，云上指定ID查询单次上限 constant.TCLBDescribeMax 个，分批并发查询
+func (hd *lbHandler) listLoadBalancerByCloudIDs(kt *kit.Kit, cloudIDs []string) ([]typeclb.TCloudClb, error) {
+
+	idBatches := slice.Split(cloudIDs, constant.TCLBDescribeMax)
+	opts := make([]*typeclb.TCloudListOption, 0, len(idBatches))
+	for _, idBatch := range idBatches {
+		page := &typecore.TCloudPage{Limit: typecore.TCloudQueryLimit}
+		opts = append(opts, hd.buildListOpt(page, idBatch))
+	}
+
+	return hd.concurrentListLoadBalancer(kt, opts)
+}
+
+// concurrentListLoadBalancer 并发执行给定的云上负载均衡查询，合并返回结果
+func (hd *lbHandler) concurrentListLoadBalancer(kt *kit.Kit, opts []*typeclb.TCloudListOption) (
+	[]typeclb.TCloudClb, error) {
+
+	eg, _ := errgroup.WithContext(kt.Ctx)
+	eg.SetLimit(int(hd.SyncConcurrent()))
+	mu := &sync.Mutex{}
+	results := make([]typeclb.TCloudClb, 0, len(opts)*typecore.TCloudQueryLimit)
+	for _, listOpt := range opts {
+		eg.Go(func() error {
+			lbResult, err := hd.syncCli.CloudCli().ListLoadBalancer(kt, listOpt)
+			if err != nil {
+				logs.Errorf("request adaptor list tcloud load balancer failed, err: %v, account: %s, "+
+					"region: %s, offset: %d, cloud_id_count: %d, rid: %s", err, hd.request.AccountID,
+					hd.request.Region, listOpt.Page.Offset, len(listOpt.CloudIDs), kt.Rid)
+				return err
+			}
+			mu.Lock()
+			results = append(results, lbResult...)
+			mu.Unlock()
+			return nil
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return nil, err
+	}
+
 	return results, nil
 }
 
@@ -133,7 +267,8 @@ func (hd *lbHandler) Sync(kt *kit.Kit, instances []typeclb.TCloudClb) error {
 		PrefetchedLB: instances,
 	}
 	if _, err := hd.syncCli.LoadBalancerWithListener(kt, params, opt); err != nil {
-		logs.Errorf("sync tcloud load balancer with rel failed, err: %v, opt: %v, rid: %s", err, params, kt.Rid)
+		logs.Errorf("sync tcloud load balancer with rel failed, err: %v, account: %s, region: %s, "+
+			"count: %d, rid: %s", err, params.AccountID, params.Region, len(params.CloudIDs), kt.Rid)
 		return err
 	}
 

--- a/cmd/hc-service/service/sync/tcloud/load_balancer_test.go
+++ b/cmd/hc-service/service/sync/tcloud/load_balancer_test.go
@@ -1,0 +1,147 @@
+/*
+ * TencentBlueKing is pleased to support the open source community by making
+ * 蓝鲸智云 - 混合云管理平台 (BlueKing - Hybrid Cloud Management System) available.
+ * Copyright (C) 2024 THL A29 Limited,
+ * a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * We undertake not to change the open source license (MIT license) applicable
+ * to the current version of the project delivered to anyone in the future.
+ */
+
+package tcloud
+
+import (
+	"testing"
+
+	typecore "hcm/pkg/adaptor/types/core"
+	typeclb "hcm/pkg/adaptor/types/load-balancer"
+	"hcm/pkg/api/core"
+	hcsync "hcm/pkg/api/hc-service/sync"
+	"hcm/pkg/cc"
+	"hcm/pkg/criteria/constant"
+	"hcm/pkg/criteria/enumor"
+	cvt "hcm/pkg/tools/converter"
+	"hcm/pkg/tools/slice"
+
+	"github.com/stretchr/testify/require"
+)
+
+var hcServiceSetting = new(cc.HCServiceSetting)
+
+func init() {
+	cc.InitRuntime(hcServiceSetting)
+}
+
+func TestBuildListOpt(t *testing.T) {
+	hd := &lbHandler{
+		baseHandler: baseHandler{
+			resType: enumor.LoadBalancerCloudResType,
+			request: &hcsync.TCloudSyncReq{
+				Region:     "ap-guangzhou",
+				TagFilters: core.MultiValueTagMap{"env": {"prod"}},
+			},
+		},
+	}
+
+	page := &typecore.TCloudPage{Offset: 0, Limit: 100}
+	cloudIDs := []string{"lb-1", "lb-2"}
+
+	opt := hd.buildListOpt(page, cloudIDs)
+
+	require.Equal(t, "ap-guangzhou", opt.Region)
+	require.Equal(t, cloudIDs, opt.CloudIDs)
+	require.Equal(t, page, opt.Page)
+	require.Equal(t, cvt.ValToPtr(typeclb.TCloudCLBOrderAscending), opt.OrderType)
+	require.Equal(t, cvt.ValToPtr(typeclb.TCloudOrderByCreateTime), opt.OrderBy)
+	require.Equal(t, core.MultiValueTagMap{"env": {"prod"}}, opt.TagFilters)
+}
+
+func TestBuildPageListOpts(t *testing.T) {
+	hd := &lbHandler{
+		baseHandler: baseHandler{
+			resType: enumor.LoadBalancerCloudResType,
+			request: &hcsync.TCloudSyncReq{
+				Region:     "ap-guangzhou",
+				Concurrent: 3,
+			},
+		},
+		offset: 0,
+	}
+
+	opts := hd.buildPageListOpts()
+
+	require.Len(t, opts, 3)
+	for i, opt := range opts {
+		require.Equal(t, uint64(i*typecore.TCloudQueryLimit), opt.Page.Offset)
+		require.Equal(t, uint64(typecore.TCloudQueryLimit), opt.Page.Limit)
+		require.Nil(t, opt.CloudIDs)
+	}
+}
+
+func TestBuildPageListOptsWithOffset(t *testing.T) {
+	hd := &lbHandler{
+		baseHandler: baseHandler{
+			resType: enumor.LoadBalancerCloudResType,
+			request: &hcsync.TCloudSyncReq{
+				Region:     "ap-guangzhou",
+				Concurrent: 2,
+			},
+		},
+		offset: 100,
+	}
+
+	opts := hd.buildPageListOpts()
+
+	require.Len(t, opts, 2)
+	require.Equal(t, uint64(100), opts[0].Page.Offset)
+	require.Equal(t, uint64(100+typecore.TCloudQueryLimit), opts[1].Page.Offset)
+}
+
+func TestListLoadBalancerByCloudIDsSplit(t *testing.T) {
+	// 21 cloud IDs should split into 2 batches: 20 + 1
+	cloudIDs := make([]string, 0, 21)
+	for i := 0; i < 21; i++ {
+		cloudIDs = append(cloudIDs, "lb-"+string(rune('a'+i)))
+	}
+
+	hd := &lbHandler{
+		baseHandler: baseHandler{
+			resType: enumor.LoadBalancerCloudResType,
+			request: &hcsync.TCloudSyncReq{
+				Region: "ap-guangzhou",
+			},
+		},
+	}
+
+	// We can't call listLoadBalancerByCloudIDs directly without mocking the cloud client,
+	// but we can verify the batching logic by checking slice.Split behavior
+	idBatches := slice.Split(cloudIDs, constant.TCLBDescribeMax)
+	require.Len(t, idBatches, 2)
+	require.Len(t, idBatches[0], 20)
+	require.Len(t, idBatches[1], 1)
+
+	// Verify buildListOpt is called with correct cloudIDs for each batch
+	for i, batch := range idBatches {
+		page := &typecore.TCloudPage{Limit: typecore.TCloudQueryLimit}
+		opt := hd.buildListOpt(page, batch)
+		require.Equal(t, batch, opt.CloudIDs)
+		require.Equal(t, uint64(typecore.TCloudQueryLimit), opt.Page.Limit)
+		_ = i
+	}
+}
+
+func TestListLoadBalancerByCloudIDsEmpty(t *testing.T) {
+	idBatches := slice.Split([]string(nil), constant.TCLBDescribeMax)
+	require.Empty(t, idBatches)
+
+	opts := make([]*typeclb.TCloudListOption, 0, len(idBatches))
+	require.Empty(t, opts)
+}

--- a/cmd/hc-service/service/sync/tcloud/service.go
+++ b/cmd/hc-service/service/sync/tcloud/service.go
@@ -58,6 +58,10 @@ func InitService(cap *capability.Capability) {
 	h.Add("SyncArgsTpl", http.MethodPost, "/argument_templates/sync", v.SyncArgsTpl)
 	h.Add("SyncCert", http.MethodPost, "/certs/sync", v.SyncCert)
 	h.Add("SyncLoadBalancer", http.MethodPost, "/load_balancers/sync", v.SyncLoadBalancer)
+	h.Add("DeleteLoadBalancerByCond", http.MethodDelete, "/load_balancers/by_condition/delete",
+		v.DeleteLoadBalancerByCond)
+	h.Add("SyncLoadBalancerByCond", http.MethodPost, "/load_balancers/by_condition/sync",
+		v.SyncLoadBalancerByCond)
 	h.Add("SyncLoadBalancerListener", http.MethodPost, "/listeners/sync", v.SyncLoadBalancerListener)
 	h.Add("SyncCvmCCInfo", http.MethodPost, "/cvms/cc_info/sync", v.SyncCvmCCInfo)
 	h.Add("SyncCvmCCInfoByCond", http.MethodPost, "/cvms/cc_info/by_condition/sync", v.SyncCvmCCInfoByCond)

--- a/cmd/task-server/logics/action/init.go
+++ b/cmd/task-server/logics/action/init.go
@@ -89,6 +89,8 @@ func register() {
 	action.RegisterAction(actionlb.BatchTaskUnBindTargetAction{})
 	action.RegisterAction(actionlb.BatchTaskModifyRsWeightAction{})
 	action.RegisterAction(actionlb.BatchTaskDeleteListenerAction{})
+	action.RegisterAction(actionlb.BatchTaskSyncLbDeleteAction{})
+	action.RegisterAction(actionlb.BatchTaskSyncLbUpsertAction{})
 
 	action.RegisterAction(actionlb.SyncTCloudLoadBalancerAction{})
 	action.RegisterAction(actionlb.SyncTCloudLoadBalancerListenerAction{})

--- a/cmd/task-server/logics/action/load-balancer/batch_task_sync_lb.go
+++ b/cmd/task-server/logics/action/load-balancer/batch_task_sync_lb.go
@@ -1,0 +1,285 @@
+/*
+ * TencentBlueKing is pleased to support the open source community by making
+ * 蓝鲸智云 - 混合云管理平台 (BlueKing - Hybrid Cloud Management System) available.
+ * Copyright (C) 2024 THL A29 Limited,
+ * a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * We undertake not to change the open source license (MIT license) applicable
+ *
+ * to the current version of the project delivered to anyone in the future.
+ */
+
+package actionlb
+
+import (
+	"fmt"
+
+	actcli "hcm/cmd/task-server/logics/action/cli"
+	actionflow "hcm/cmd/task-server/logics/flow"
+	"hcm/pkg/api/core"
+	hcsync "hcm/pkg/api/hc-service/sync"
+	"hcm/pkg/async/action"
+	"hcm/pkg/async/action/run"
+	"hcm/pkg/criteria/enumor"
+	"hcm/pkg/criteria/errf"
+	"hcm/pkg/criteria/validator"
+	"hcm/pkg/kit"
+	"hcm/pkg/logs"
+)
+
+// --------------------------[批量操作-批量删除云上已不存在的负载均衡]-----------------------------
+
+var _ action.Action = new(BatchTaskSyncLbDeleteAction)
+var _ action.ParameterAction = new(BatchTaskSyncLbDeleteAction)
+
+// BatchTaskSyncLbDeleteAction 批量操作-批量删除云上已不存在的负载均衡
+type BatchTaskSyncLbDeleteAction struct{}
+
+// BatchTaskSyncLbDeleteOption 批量操作-批量删除云上已不存在的负载均衡
+type BatchTaskSyncLbDeleteOption struct {
+	Vendor    enumor.Vendor `json:"vendor" validate:"required"`
+	AccountID string        `json:"account_id" validate:"required"`
+	Region    string        `json:"region" validate:"required"`
+	// ManagementDetailIDs 对应的详情行id列表，需要和 CloudIDs 长度对应
+	ManagementDetailIDs []string `json:"management_detail_ids" validate:"required,min=1"`
+	// CloudIDs 本批次待删除的负载均衡云上ID列表
+	CloudIDs []string `json:"cloud_ids" validate:"required,min=1"`
+}
+
+// Validate validate option.
+func (opt BatchTaskSyncLbDeleteOption) Validate() error {
+	if err := validateSyncLbVendor(opt.Vendor); err != nil {
+		return err
+	}
+
+	if len(opt.ManagementDetailIDs) != len(opt.CloudIDs) {
+		return errf.Newf(errf.InvalidParameter, "management_detail_ids and cloud_ids num not match, %d != %d",
+			len(opt.ManagementDetailIDs), len(opt.CloudIDs))
+	}
+
+	return validator.Validate.Struct(opt)
+}
+
+// ParameterNew return request params.
+func (act BatchTaskSyncLbDeleteAction) ParameterNew() (params any) {
+	return new(BatchTaskSyncLbDeleteOption)
+}
+
+// Name return action name
+func (act BatchTaskSyncLbDeleteAction) Name() enumor.ActionName {
+	return enumor.ActionBatchTaskSyncLbDelete
+}
+
+// Run 批量删除云上已不存在的负载均衡，按云上ID精确删除，支持重入
+func (act BatchTaskSyncLbDeleteAction) Run(kt run.ExecuteKit, params any) (result any, taskErr error) {
+	opt, ok := params.(*BatchTaskSyncLbDeleteOption)
+	if !ok {
+		return nil, errf.New(errf.InvalidParameter, "params type is not BatchTaskSyncLbDeleteOption")
+	}
+
+	reason, err := prepareSyncLbTaskDetails(kt.Kit(), opt.ManagementDetailIDs)
+	if err != nil {
+		return nil, err
+	}
+	if len(reason) > 0 {
+		return reason, nil
+	}
+
+	defer func() {
+		finishSyncLbTaskDetails(kt.Kit(), opt.ManagementDetailIDs, taskErr)
+	}()
+
+	// 使用异步来源的kit，令hc-service开启云上接口的限频重试
+	if taskErr = act.deleteLoadBalancer(kt.AsyncKit(), opt); taskErr != nil {
+		logs.Errorf("batch delete load balancer failed, err: %v, account: %s, region: %s, cloudIDs: %v, rid: %s",
+			taskErr, opt.AccountID, opt.Region, opt.CloudIDs, kt.Kit().Rid)
+		return nil, taskErr
+	}
+
+	logs.Infof("batch delete load balancer success, account: %s, region: %s, count: %d, rid: %s",
+		opt.AccountID, opt.Region, len(opt.CloudIDs), kt.Kit().Rid)
+
+	return nil, nil
+}
+
+// deleteLoadBalancer 调用hc-service删除本批负载均衡，云上ID由上游条件同步比对得出
+func (act BatchTaskSyncLbDeleteAction) deleteLoadBalancer(kt *kit.Kit, opt *BatchTaskSyncLbDeleteOption) error {
+	req := &hcsync.TCloudDelLoadBalancerByCondReq{
+		AccountID: opt.AccountID,
+		Region:    opt.Region,
+		CloudIDs:  opt.CloudIDs,
+	}
+
+	switch opt.Vendor {
+	case enumor.TCloud:
+		return actcli.GetHCService().TCloud.Clb.DeleteLoadBalancerByCond(kt, req)
+	default:
+		return fmt.Errorf("unsupport vendor for batch sync load balancer delete: %s", opt.Vendor)
+	}
+}
+
+// Rollback 批量删除负载均衡支持重入，无需回滚
+func (act BatchTaskSyncLbDeleteAction) Rollback(kt run.ExecuteKit, params any) error {
+	logs.Infof(" ----------- BatchTaskSyncLbDeleteAction Rollback -----------, params: %+v, rid: %s",
+		params, kt.Kit().Rid)
+	return nil
+}
+
+// --------------------------[批量操作-批量同步负载均衡]-----------------------------
+
+var _ action.Action = new(BatchTaskSyncLbUpsertAction)
+var _ action.ParameterAction = new(BatchTaskSyncLbUpsertAction)
+
+// BatchTaskSyncLbUpsertAction 批量操作-批量同步负载均衡
+type BatchTaskSyncLbUpsertAction struct{}
+
+// BatchTaskSyncLbUpsertOption 批量操作-批量同步负载均衡
+type BatchTaskSyncLbUpsertOption struct {
+	Vendor    enumor.Vendor `json:"vendor" validate:"required"`
+	AccountID string        `json:"account_id" validate:"required"`
+	Region    string        `json:"region" validate:"required"`
+	// ManagementDetailIDs 对应的详情行id列表，需要和 CloudIDs 长度对应
+	ManagementDetailIDs []string `json:"management_detail_ids" validate:"required,min=1"`
+	// CloudIDs 本批次待同步的负载均衡云上ID列表
+	CloudIDs []string `json:"cloud_ids" validate:"required,min=1"`
+	// TagFilters 标签过滤条件，与创建任务时的条件保持一致
+	TagFilters core.MultiValueTagMap `json:"tag_filters,omitempty"`
+}
+
+// Validate validate option.
+func (opt BatchTaskSyncLbUpsertOption) Validate() error {
+	if err := validateSyncLbVendor(opt.Vendor); err != nil {
+		return err
+	}
+
+	if len(opt.ManagementDetailIDs) != len(opt.CloudIDs) {
+		return errf.Newf(errf.InvalidParameter, "management_detail_ids and cloud_ids num not match, %d != %d",
+			len(opt.ManagementDetailIDs), len(opt.CloudIDs))
+	}
+
+	return validator.Validate.Struct(opt)
+}
+
+// ParameterNew return request params.
+func (act BatchTaskSyncLbUpsertAction) ParameterNew() (params any) {
+	return new(BatchTaskSyncLbUpsertOption)
+}
+
+// Name return action name
+func (act BatchTaskSyncLbUpsertAction) Name() enumor.ActionName {
+	return enumor.ActionBatchTaskSyncLbUpsert
+}
+
+// Run 批量同步负载均衡，同步为覆盖写，支持重入
+func (act BatchTaskSyncLbUpsertAction) Run(kt run.ExecuteKit, params any) (result any, taskErr error) {
+	opt, ok := params.(*BatchTaskSyncLbUpsertOption)
+	if !ok {
+		return nil, errf.New(errf.InvalidParameter, "params type is not BatchTaskSyncLbUpsertOption")
+	}
+
+	reason, err := prepareSyncLbTaskDetails(kt.Kit(), opt.ManagementDetailIDs)
+	if err != nil {
+		return nil, err
+	}
+	if len(reason) > 0 {
+		return reason, nil
+	}
+
+	defer func() {
+		finishSyncLbTaskDetails(kt.Kit(), opt.ManagementDetailIDs, taskErr)
+	}()
+
+	// 使用异步来源的kit，令hc-service开启云上接口的限频重试
+	if taskErr = act.syncLoadBalancer(kt.AsyncKit(), opt); taskErr != nil {
+		logs.Errorf("batch sync load balancer failed, err: %v, account: %s, region: %s, cloudIDs: %v, rid: %s",
+			taskErr, opt.AccountID, opt.Region, opt.CloudIDs, kt.Kit().Rid)
+		return nil, taskErr
+	}
+
+	logs.Infof("batch sync load balancer success, account: %s, region: %s, count: %d, rid: %s",
+		opt.AccountID, opt.Region, len(opt.CloudIDs), kt.Kit().Rid)
+
+	return nil, nil
+}
+
+// syncLoadBalancer 调用hc-service同步本批负载均衡，同步不清理DB，云上已删除的由删除动作处理
+func (act BatchTaskSyncLbUpsertAction) syncLoadBalancer(kt *kit.Kit, opt *BatchTaskSyncLbUpsertOption) error {
+	req := &hcsync.TCloudSyncLoadBalancerByCondReq{
+		AccountID:  opt.AccountID,
+		Region:     opt.Region,
+		CloudIDs:   opt.CloudIDs,
+		TagFilters: opt.TagFilters,
+	}
+
+	switch opt.Vendor {
+	case enumor.TCloud:
+		return actcli.GetHCService().TCloud.Clb.SyncLoadBalancerByCond(kt, req)
+	default:
+		return fmt.Errorf("unsupport vendor for batch sync load balancer upsert: %s", opt.Vendor)
+	}
+}
+
+// Rollback 批量同步负载均衡支持重入，无需回滚
+func (act BatchTaskSyncLbUpsertAction) Rollback(kt run.ExecuteKit, params any) error {
+	logs.Infof(" ----------- BatchTaskSyncLbUpsertAction Rollback -----------, params: %+v, rid: %s",
+		params, kt.Kit().Rid)
+	return nil
+}
+
+func validateSyncLbVendor(vendor enumor.Vendor) error {
+	switch vendor {
+	case enumor.TCloud:
+		return nil
+	default:
+		return fmt.Errorf("unsupport vendor for batch sync load balancer: %s", vendor)
+	}
+}
+
+// prepareSyncLbTaskDetails 校验本批任务详情状态并置为执行中。
+// 返回非空 reason 表示本批已被取消，调用方跳过本批且不视为失败。
+func prepareSyncLbTaskDetails(kt *kit.Kit, detailIDs []string) (string, error) {
+	detailList, err := actionflow.ListTaskDetail(kt, detailIDs)
+	if err != nil {
+		logs.Errorf("list task detail failed, err: %v, detailIDs: %v, rid: %s", err, detailIDs, kt.Rid)
+		return "", err
+	}
+
+	for _, detail := range detailList {
+		if detail.State == enumor.TaskDetailCancel {
+			return fmt.Sprintf("task detail task: %s is canceled", detail.ID), nil
+		}
+		if detail.State != enumor.TaskDetailInit {
+			return "", errf.Newf(errf.InvalidParameter, "task management detail(%s) status(%s) is not init",
+				detail.ID, detail.State)
+		}
+	}
+
+	if err = actionflow.BatchUpdateTaskDetailState(kt, detailIDs, enumor.TaskDetailRunning); err != nil {
+		logs.Errorf("update task detail state to running failed, err: %v, detailIDs: %v, rid: %s",
+			err, detailIDs, kt.Rid)
+		return "", err
+	}
+
+	return "", nil
+}
+
+// finishSyncLbTaskDetails 按本批执行结果写回任务详情状态，写回失败只记录日志，不影响动作结果
+func finishSyncLbTaskDetails(kt *kit.Kit, detailIDs []string, taskErr error) {
+	state := enumor.TaskDetailSuccess
+	if taskErr != nil {
+		state = enumor.TaskDetailFailed
+	}
+
+	if err := actionflow.BatchUpdateTaskDetailResultState(kt, detailIDs, state, nil, taskErr); err != nil {
+		logs.Errorf("update task detail state to %s failed, err: %v, detailIDs: %v, rid: %s",
+			state, err, detailIDs, kt.Rid)
+	}
+}

--- a/docs/api-docs/api-server/docs/zh/list_biz_task_detail_by_cond.md
+++ b/docs/api-docs/api-server/docs/zh/list_biz_task_detail_by_cond.md
@@ -92,7 +92,7 @@ POST /api/v1/cloud/bizs/{bk_biz_id}/task_details/list_by_cond
 | task_management_id | string       | 关联的任务管理数据的唯一标识                                                             |
 | flow_id            | string       | 关联的异步任务flow的唯一标识                                                            |
 | task_action_ids    | string array | 关联的异步任务task的aciton id数组                                                       |
-| operation          | string       | 操作（创建4层监听器：create_layer4_listener、创建7层监听器：create_layer7_listener、绑定4层RS：binding_layer4_rs、绑定7层RS：binding_layer7_rs、创建URL规则：create_layer7_rule、解绑4层RS：listener_layer4_unbind_rs、解绑7层RS：listener_layer7_unbind_rs、调整4层权重：listener_layer4_rs_weight、调整7层权重：listener_layer7_rs_weight、删除监听器：listener_delete、开机：start_cvm、关机：stop_cvm、重启：reboot_cvm、重装：cvm_reset_system） |
+| operation          | string       | 操作（创建4层监听器：create_layer4_listener、创建7层监听器：create_layer7_listener、绑定4层RS：binding_layer4_rs、绑定7层RS：binding_layer7_rs、创建URL规则：create_layer7_rule、解绑4层RS：listener_layer4_unbind_rs、解绑7层RS：listener_layer7_unbind_rs、调整4层权重：listener_layer4_rs_weight、调整7层权重：listener_layer7_rs_weight、删除监听器：listener_delete、同步负载均衡：sync_load_balancer、开机：start_cvm、关机：stop_cvm、重启：reboot_cvm、重装：cvm_reset_system） |
 | param              | json         | 任务详情数据                                                                          |
 | result             | json         | 任务详情执行结果                                                                       |
 | state              | string       | 任务状态，如：init（待执行）、running（运行）、failed（失败）、success（成功）、cancel（取消） |

--- a/docs/api-docs/api-server/docs/zh/list_biz_task_management_by_cond.md
+++ b/docs/api-docs/api-server/docs/zh/list_biz_task_management_by_cond.md
@@ -18,7 +18,7 @@ POST /api/v1/cloud/bizs/{bk_biz_id}/task_managements/list_by_cond
 | end_time         | string       | 是   | 任务最晚开始时间，格式：2025-01-01 23:59:59，任务时间跨度最大支持1个月 |
 | page             | object       | 是   | 分页设置                    |
 | account_ids      | string array | 否   | 账号ID，最大查询数量10个      |
-| operations       | string array | 否   | 任务操作类型，最大查询数量10个（创建4层监听器：create_layer4_listener、创建7层监听器：create_layer7_listener、绑定4层RS：binding_layer4_rs、绑定7层RS：binding_layer7_rs、创建URL规则：create_layer7_rule、解绑4层RS：listener_layer4_unbind_rs、解绑7层RS：listener_layer7_unbind_rs、调整4层权重：listener_layer4_rs_weight、调整7层权重：listener_layer7_rs_weight、删除监听器：listener_delete、开机：start_cvm、关机：stop_cvm、重启：reboot_cvm、重装：cvm_reset_system） |
+| operations       | string array | 否   | 任务操作类型，最大查询数量10个（创建4层监听器：create_layer4_listener、创建7层监听器：create_layer7_listener、绑定4层RS：binding_layer4_rs、绑定7层RS：binding_layer7_rs、创建URL规则：create_layer7_rule、解绑4层RS：listener_layer4_unbind_rs、解绑7层RS：listener_layer7_unbind_rs、调整4层权重：listener_layer4_rs_weight、调整7层权重：listener_layer7_rs_weight、删除监听器：listener_delete、同步负载均衡：sync_load_balancer、开机：start_cvm、关机：stop_cvm、重启：reboot_cvm、重装：cvm_reset_system） |
 | source           | string       | 否   | 任务来源，如：标准运维插件(sops)、excel导入(excel)、API调用(api)、页面操作(web) |
 | state            | string       | 否   | 任务状态，如：为running（运行中）、failed（失败）、success（成功）、deliver_partial（部分成功）、cancel（取消） |
 | creator          | string       | 否   | 操作人                      |
@@ -120,7 +120,7 @@ POST /api/v1/cloud/bizs/{bk_biz_id}/task_managements/list_by_cond
 | state       | string       | 任务状态，如：为running（运行中）、failed（失败）、success（成功）、deliver_partial（部分成功）、cancel（取消） |
 | account_ids | string array | 账号ID                                                                         |
 | resource    | string       | 资源类型，如: clb、host                                                          |
-| operations  | string array | 操作（创建4层监听器：create_layer4_listener、创建7层监听器：create_layer7_listener、绑定4层RS：binding_layer4_rs、绑定7层RS：binding_layer7_rs、创建URL规则：create_layer7_rule、解绑4层RS：listener_layer4_unbind_rs、解绑7层RS：listener_layer7_unbind_rs、调整4层权重：listener_layer4_rs_weight、调整7层权重：listener_layer7_rs_weight、删除监听器：listener_delete、开机：start_cvm、关机：stop_cvm、重启：reboot_cvm、重装：cvm_reset_system）|
+| operations  | string array | 操作（创建4层监听器：create_layer4_listener、创建7层监听器：create_layer7_listener、绑定4层RS：binding_layer4_rs、绑定7层RS：binding_layer7_rs、创建URL规则：create_layer7_rule、解绑4层RS：listener_layer4_unbind_rs、解绑7层RS：listener_layer7_unbind_rs、调整4层权重：listener_layer4_rs_weight、调整7层权重：listener_layer7_rs_weight、删除监听器：listener_delete、同步负载均衡：sync_load_balancer、开机：start_cvm、关机：stop_cvm、重启：reboot_cvm、重装：cvm_reset_system）|
 | flow_ids    | string array | 关联的后台异步任务flow id数组                                                      |
 | extension   | object       | 扩展字段                                                                         |
 | creator     | string       | 创建者                                       |

--- a/docs/api-docs/web-server/docs/biz/sync_biz_resource_by_cond.md
+++ b/docs/api-docs/web-server/docs/biz/sync_biz_resource_by_cond.md
@@ -15,7 +15,9 @@ POST /api/v1/cloud/bizs/{bk_biz_id}/vendors/{vendor}/accounts/{account_id}/resou
 | bk_biz_id  | int    | 是  | 同步业务                                                 |
 | vendor     | string | 是  | 云厂商                                                  |
 | account_id | string | 是  | 账号ID                                                 |
-| res        | string | 是  | 资源名称 目前仅支持 security_group, load_balancer(仅支持tcloud)、sub_account |
+| res        | string | 是  | 资源名称 目前仅支持 security_group, load_balancer(仅支持 tcloud)、sub_account |
+
+> `res=load_balancer` 且 vendor 为 `tcloud` 时走异步任务：接口立即返回 `task_management_id`，实际同步在任务中心执行。其他资源仍为同步接口，`data` 为空。
 
 #### vendor=tcloud
 
@@ -83,10 +85,24 @@ POST /api/v1/cloud/bizs/{bk_biz_id}/vendors/{vendor}/accounts/{account_id}/resou
 
 ### 响应示例
 
+#### 同步资源（非负载均衡）
+
 ```json
 {
   "code": 0,
   "message": "ok"
+}
+```
+
+#### 异步同步负载均衡（res=load_balancer）
+
+```json
+{
+  "code": 0,
+  "message": "ok",
+  "data": {
+    "task_management_id": "000000xw"
+  }
 }
 ```
 
@@ -96,3 +112,10 @@ POST /api/v1/cloud/bizs/{bk_biz_id}/vendors/{vendor}/accounts/{account_id}/resou
 |---------|--------|------|
 | code    | int32  | 状态码  |
 | message | string | 请求信息 |
+| data    | object | CLB 异步同步时返回任务信息，其他资源为空 |
+
+#### data（仅 res=load_balancer）
+
+| 参数名称               | 参数类型   | 描述                          |
+|--------------------|--------|-----------------------------|
+| task_management_id | string | 任务管理 ID。请求条件下没有任何可处理的 CLB 时不创建任务，该字段为空字符串 |

--- a/docs/api-docs/web-server/docs/biz/task/list_task_detail.md
+++ b/docs/api-docs/web-server/docs/biz/task/list_task_detail.md
@@ -242,7 +242,31 @@ POST /api/v1/cloud/bizs/{bk_biz_id}/task_details/list
 
 #### detail.param 参数说明
 
-param的内容和operation对应
+param的内容和operation对应。
+
+##### operation=sync_load_balancer
+
+示例数据
+
+```json
+{
+  "op": "update",
+  "account_id": "0000002b",
+  "cloud_lb_id": "lb-2ita2syu",
+  "clb_vip_domain": "9.131.91.86",
+  "domain": "",
+  "region": "ap-hongkong"
+}
+```
+
+| 参数名称         | 参数类型   | 描述                                                          |
+|--------------|--------|--------------------------------------------------------------------|
+| op           | string | 本条 CLB 的同步类别，前端「类别」列：`create`（新增）、`update`（修改）、`delete`（删除） |
+| account_id   | string | 账号ID                                                               |
+| cloud_lb_id  | string | 云上负载均衡ID，前端「CLB ID」列，与其他 CLB 任务字段名一致                |
+| clb_vip_domain | string | 负载均衡 VIP，前端「CLB VIP/域名」列。优先 IPv4，无 IPv4 时写 IPv6      |
+| domain       | string | 负载均衡域名                                                          |
+| region       | string | 地域                                                                 |
 
 ##### operation=target_group_remove_rs
 

--- a/docs/api-docs/web-server/docs/biz/task/list_task_management.md
+++ b/docs/api-docs/web-server/docs/biz/task/list_task_management.md
@@ -232,7 +232,7 @@ POST /api/v1/cloud/bizs/{bk_biz_id}/task_managements/list
 | state      | string       | 任务状态，如：为running（运行中）、failed（失败）、success（成功）、deliver_partial（部分成功）、cancel（取消） |
 | account_id | string       | 账号ID                                                                         |
 | resource   | string       | 资源类型，如: clb、host                                                             |
-| operations | string array | 操作                                                                           |
+| operations | string array | 操作。CLB 条件同步为 `sync_load_balancer`                                          |
 | flow_ids   | string array | 关联的后台异步任务flow id数组                                                           |
 | extension  | object       | 扩展字段                                                                         |
 | creator    | string       | 创建者                                  |

--- a/docs/api-docs/web-server/docs/resource/sync_resource_by_cond.md
+++ b/docs/api-docs/web-server/docs/resource/sync_resource_by_cond.md
@@ -16,6 +16,8 @@ POST /api/v1/cloud/vendors/{vendor}/accounts/{account_id}/resources/{res}/sync_b
 | account_id | string | 是  | 账号ID                                                |
 | res        | string | 是  | 资源名称 目前仅支持 security_group, load_balancer(仅支持tcloud) |
 
+> `res=load_balancer` 且 vendor 为 `tcloud` 时走异步任务：接口立即返回 `task_management_id`，实际同步在任务中心执行。其他资源仍为同步接口，`data` 为空。
+
 #### vendor=tcloud
 
 | 参数名称        | 参数类型                | 必选 | 描述               |
@@ -76,10 +78,24 @@ POST /api/v1/cloud/vendors/{vendor}/accounts/{account_id}/resources/{res}/sync_b
 
 ### 响应示例
 
+#### 同步资源（非 CLB）
+
 ```json
 {
   "code": 0,
   "message": "ok"
+}
+```
+
+#### 异步同步负载均衡（res=load_balancer）
+
+```json
+{
+  "code": 0,
+  "message": "ok",
+  "data": {
+    "task_management_id": "000000xw"
+  }
 }
 ```
 
@@ -89,3 +105,10 @@ POST /api/v1/cloud/vendors/{vendor}/accounts/{account_id}/resources/{res}/sync_b
 |---------|--------|------|
 | code    | int32  | 状态码  |
 | message | string | 请求信息 |
+| data    | object | CLB 异步同步时返回任务信息，其他资源为空 |
+
+#### data（仅 res=load_balancer）
+
+| 参数名称               | 参数类型   | 描述                          |
+|--------------------|--------|-----------------------------|
+| task_management_id | string | 任务管理 ID。请求条件下没有任何可处理的 CLB 时不创建任务，该字段为空字符串 |

--- a/docs/support-file/helm/values.yaml
+++ b/docs/support-file/helm/values.yaml
@@ -285,6 +285,12 @@ cloudserver:
   port: 80
   concurrentConfig:
     clbImportCount: 10
+    clbCondSync:
+      deleteBatchSize: 100
+      upsertBatchSize: 500
+      largeUpsertThreshold: 10000
+      largeUpsertBatchSize: 2500
+      listConcurrent: 5
 
 dataservice:
   ## 镜像

--- a/pkg/adaptor/tcloud/clb.go
+++ b/pkg/adaptor/tcloud/clb.go
@@ -40,6 +40,19 @@ import (
 // ListLoadBalancer 查询clb列表：如果指定的LoadBalancerIds不存在，该接口不会报错
 // reference: https://cloud.tencent.com/document/api/214/30685
 func (t *TCloudImpl) ListLoadBalancer(kt *kit.Kit, opt *typelb.TCloudListOption) ([]typelb.TCloudClb, error) {
+	result, err := t.ListLoadBalancerWithCount(kt, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return result.Details, nil
+}
+
+// ListLoadBalancerWithCount 查询clb列表及总数：如果指定的LoadBalancerIds不存在，该接口不会报错
+// reference: https://cloud.tencent.com/document/api/214/30685
+func (t *TCloudImpl) ListLoadBalancerWithCount(kt *kit.Kit, opt *typelb.TCloudListOption) (
+	*typelb.TCloudListResult, error) {
+
 	if opt == nil {
 		return nil, errf.New(errf.InvalidParameter, "list option is required")
 	}
@@ -76,7 +89,13 @@ func (t *TCloudImpl) ListLoadBalancer(kt *kit.Kit, opt *typelb.TCloudListOption)
 
 	resp, err := NetworkErrRetry(client.DescribeLoadBalancersWithContext, kt, req)
 	if err != nil {
-		logs.Errorf("fail to describe lodabalancer from tcloud, err: %v, req: %+v, rid: %s", err, req, kt.Rid)
+		var offset, limit uint64
+		if opt.Page != nil {
+			offset = opt.Page.Offset
+			limit = opt.Page.Limit
+		}
+		logs.Errorf("fail to describe load balancer from tcloud, err: %v, region: %s, offset: %d, limit: %d, "+
+			"cloud_id_count: %d, rid: %s", err, opt.Region, offset, limit, len(opt.CloudIDs), kt.Rid)
 		return nil, err
 	}
 
@@ -88,7 +107,10 @@ func (t *TCloudImpl) ListLoadBalancer(kt *kit.Kit, opt *typelb.TCloudListOption)
 		clbs = append(clbs, typelb.TCloudClb{LoadBalancer: one})
 	}
 
-	return clbs, nil
+	return &typelb.TCloudListResult{
+		Details:    clbs,
+		TotalCount: cvt.PtrToVal(resp.Response.TotalCount),
+	}, nil
 }
 
 // CountClb count clb of region

--- a/pkg/adaptor/tcloud/interface.go
+++ b/pkg/adaptor/tcloud/interface.go
@@ -187,6 +187,7 @@ type TCloud interface {
 		*poller.BaseDoneResult, error)
 	CreateLoadBalancer(kt *kit.Kit, opt *typelb.TCloudCreateClbOption) (*poller.BaseDoneResult, error)
 	ListLoadBalancer(kt *kit.Kit, opt *typelb.TCloudListOption) ([]typelb.TCloudClb, error)
+	ListLoadBalancerWithCount(kt *kit.Kit, opt *typelb.TCloudListOption) (*typelb.TCloudListResult, error)
 	DescribeResources(kt *kit.Kit, opt *typelb.TCloudDescribeResourcesOption) (
 		*tclb.DescribeResourcesResponseParams, error)
 	DescribeNetworkAccountType(kt *kit.Kit) (*v20170312.DescribeNetworkAccountTypeResponseParams, error)

--- a/pkg/adaptor/types/load-balancer/tcloud.go
+++ b/pkg/adaptor/types/load-balancer/tcloud.go
@@ -163,6 +163,12 @@ type TCloudListOption struct {
 	TagFilters apicore.MultiValueTagMap `json:"tag_filters"`
 }
 
+// TCloudListResult defines the result of list tcloud clb instances.
+type TCloudListResult struct {
+	Details    []TCloudClb `json:"details"`
+	TotalCount uint64      `json:"total_count"`
+}
+
 // Validate tcloud clb list option.
 func (opt TCloudListOption) Validate() error {
 	if err := validator.Validate.Struct(opt); err != nil {

--- a/pkg/api/core/cloud/load-balancer/load_balancer.go
+++ b/pkg/api/core/cloud/load-balancer/load_balancer.go
@@ -56,6 +56,26 @@ type SummaryBalancer struct {
 	PublicIPv6Addresses []string `json:"public_ipv6_addresses"`
 }
 
+// LoadBalancerBriefFields defines db fields needed by LoadBalancerBrief.
+var LoadBalancerBriefFields = []string{
+	"cloud_id",
+	"region",
+	"domain",
+	"private_ipv4_addresses",
+	"private_ipv6_addresses",
+	"public_ipv4_addresses",
+	"public_ipv6_addresses",
+}
+
+// LoadBalancerBrief defines load balancer brief info.
+type LoadBalancerBrief struct {
+	CloudID     string `json:"cloud_id"`
+	Region      string `json:"region"`
+	Address     string `json:"address"`
+	AddressIPv6 string `json:"address_ipv6"`
+	Domain      string `json:"domain"`
+}
+
 // BaseLoadBalancer define base clb.
 type BaseLoadBalancer struct {
 	ID               string               `json:"id"`

--- a/pkg/api/hc-service/load-balancer/tcloud.go
+++ b/pkg/api/hc-service/load-balancer/tcloud.go
@@ -160,6 +160,17 @@ type TCloudListOption struct {
 	Region    string           `json:"region" validate:"required"`
 	CloudIDs  []string         `json:"cloud_ids" validate:"omitempty,max=200"`
 	Page      *core.TCloudPage `json:"page" validate:"omitempty"`
+
+	OrderBy   *typelb.TCloudClbListOrderByField `json:"order_by" validate:"omitempty"`
+	OrderType *int64                            `json:"order_type" validate:"omitempty"`
+
+	TagFilters apicore.MultiValueTagMap `json:"tag_filters" validate:"omitempty"`
+}
+
+// TCloudListResult defines the result of list tcloud clb instances.
+type TCloudListResult struct {
+	Details    []typelb.TCloudClb `json:"details"`
+	TotalCount uint64             `json:"total_count"`
 }
 
 // Validate tcloud clb list option.

--- a/pkg/api/hc-service/sync/sync.go
+++ b/pkg/api/hc-service/sync/sync.go
@@ -21,6 +21,8 @@
 package sync
 
 import (
+	"fmt"
+
 	"hcm/pkg/api/core"
 	"hcm/pkg/criteria/validator"
 )
@@ -49,6 +51,40 @@ type TCloudSyncReq struct {
 
 // Validate tcloud sync request.
 func (req *TCloudSyncReq) Validate() error {
+	return validator.Validate.Struct(req)
+}
+
+// TCloudDelLoadBalancerByCondReq tcloud delete load balancer by condition request.
+type TCloudDelLoadBalancerByCondReq struct {
+	AccountID string   `json:"account_id" validate:"required"`
+	Region    string   `json:"region" validate:"required"`
+	CloudIDs  []string `json:"cloud_ids" validate:"required,min=1,dive,required"`
+}
+
+// Validate ...
+func (req *TCloudDelLoadBalancerByCondReq) Validate() error {
+	if len(req.CloudIDs) == 0 {
+		return fmt.Errorf("cloud_ids is required")
+	}
+
+	return validator.Validate.Struct(req)
+}
+
+// TCloudSyncLoadBalancerByCondReq tcloud sync load balancer by condition request.
+type TCloudSyncLoadBalancerByCondReq struct {
+	AccountID string   `json:"account_id" validate:"required"`
+	Region    string   `json:"region" validate:"required"`
+	CloudIDs  []string `json:"cloud_ids" validate:"required,min=1,dive,required"`
+	// 指定标签同步，与创建同步任务时的条件保持一致
+	TagFilters core.MultiValueTagMap `json:"tag_filters,omitempty"`
+}
+
+// Validate ...
+func (req *TCloudSyncLoadBalancerByCondReq) Validate() error {
+	if len(req.CloudIDs) == 0 {
+		return fmt.Errorf("cloud_ids is required")
+	}
+
 	return validator.Validate.Struct(req)
 }
 

--- a/pkg/async/consumer/scheduler.go
+++ b/pkg/async/consumer/scheduler.go
@@ -794,9 +794,9 @@ func (sch *scheduler) executeNext(kt *kit.Kit, task *Task) error {
 				)
 				// new generic flow exec metric (terminal-state cost).
 				dims := getShareDataMetricDims(task.Flow.ShareData)
-				sch.mc.flowExecCostSec.WithLabelValues(dims.bkBizIDLabel(), dims.vendor, dims.operation,
-					string(task.Flow.Name), string(enumor.FlowSuccess)).Observe(cost.Seconds())
-			}
+			sch.mc.flowExecCostSec.WithLabelValues(dims.bkBizIDLabel(), dims.vendor, dims.operation,
+				string(task.Flow.Name), string(enumor.FlowSuccess)).Observe(cost.Seconds())
+		}
 
 			sch.DeleteFlowTaskTree(task.FlowID)
 			sch.flowTypeRunningNumMap.Inc(string(task.Flow.Name), -1)
@@ -813,9 +813,10 @@ func (sch *scheduler) executeNext(kt *kit.Kit, task *Task) error {
 			dims := getShareDataMetricDims(task.Flow.ShareData)
 			if entryTime, exists := sch.flowEntryTimeMap.Load(task.FlowID); exists {
 				if t, ok := entryTime.(time.Time); ok {
-					sch.mc.flowExecCostSec.WithLabelValues(dims.bkBizIDLabel(), dims.vendor, dims.operation,
-						string(task.Flow.Name), string(enumor.FlowFailed)).Observe(time.Since(t).Seconds())
-				}
+					cost := time.Since(t)
+				sch.mc.flowExecCostSec.WithLabelValues(dims.bkBizIDLabel(), dims.vendor, dims.operation,
+					string(task.Flow.Name), string(enumor.FlowFailed)).Observe(cost.Seconds())
+			}
 			}
 			sch.mc.flowFailTotal.WithLabelValues(dims.bkBizIDLabel(), dims.vendor, dims.operation,
 				string(task.Flow.Name), string(enumor.FlowFailed), metrics.ErrTypeHCMError.String()).Inc()

--- a/pkg/cc/service.go
+++ b/pkg/cc/service.go
@@ -216,6 +216,10 @@ func (s CloudServerSetting) Validate() error {
 		return fmt.Errorf("ccHostPoolBiz should not be empty")
 	}
 
+	if err := s.ConcurrentConfig.validate(); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/cc/types.go
+++ b/pkg/cc/types.go
@@ -1189,13 +1189,84 @@ type TenantConfig struct {
 
 // ConcurrentConfig CLB import config
 type ConcurrentConfig struct {
-	CLBImportCount int `yaml:"clbImportCount"`
+	CLBImportCount int         `yaml:"clbImportCount"`
+	ClbCondSync    ClbCondSync `yaml:"clbCondSync"`
 }
 
 func (c *ConcurrentConfig) trySetDefault() {
 	if c.CLBImportCount == 0 {
 		c.CLBImportCount = 10
 	}
+	c.ClbCondSync.trySetDefault()
+}
+
+// validate ConcurrentConfig option.
+func (c ConcurrentConfig) validate() error {
+	return c.ClbCondSync.validate()
+}
+
+// ClbCondSync 负载均衡条件同步配置。
+type ClbCondSync struct {
+	// DeleteBatchSize 单个清理任务动作处理的负载均衡数量，必须大于 0。
+	DeleteBatchSize *int `yaml:"deleteBatchSize"`
+	// UpsertBatchSize 单个同步任务动作处理的负载均衡数量，必须大于 0。
+	UpsertBatchSize *int `yaml:"upsertBatchSize"`
+	// LargeUpsertThreshold 待同步负载均衡数量超过该阈值时改用 LargeUpsertBatchSize 分批，必须大于 0。
+	LargeUpsertThreshold *int `yaml:"largeUpsertThreshold"`
+	// LargeUpsertBatchSize 待同步数量超过阈值后，单个同步任务动作处理的负载均衡数量，必须大于 0。
+	LargeUpsertBatchSize *int `yaml:"largeUpsertBatchSize"`
+	// ListConcurrent 启动阶段单地域拉取云上简要信息的分页并发，必须大于 0。
+	ListConcurrent *int `yaml:"listConcurrent"`
+}
+
+func (c *ClbCondSync) trySetDefault() {
+	if c.DeleteBatchSize == nil {
+		c.DeleteBatchSize = cvt.ValToPtr(constant.DefaultCondSyncLbDeleteBatchSize)
+	}
+	if c.UpsertBatchSize == nil {
+		c.UpsertBatchSize = cvt.ValToPtr(constant.DefaultCondSyncLbUpsertBatchSize)
+	}
+	if c.LargeUpsertThreshold == nil {
+		c.LargeUpsertThreshold = cvt.ValToPtr(constant.DefaultCondSyncLbLargeUpsertThreshold)
+	}
+	if c.LargeUpsertBatchSize == nil {
+		c.LargeUpsertBatchSize = cvt.ValToPtr(constant.DefaultCondSyncLbLargeUpsertBatchSize)
+	}
+	if c.ListConcurrent == nil {
+		c.ListConcurrent = cvt.ValToPtr(constant.DefaultCondSyncLbListConcurrent)
+	}
+}
+
+// validate ClbCondSync option.
+func (c ClbCondSync) validate() error {
+	deleteBatchSize := cvt.PtrToVal(c.DeleteBatchSize)
+	if deleteBatchSize <= 0 {
+		return fmt.Errorf("clbCondSync.deleteBatchSize should be greater than 0, but got %d", deleteBatchSize)
+	}
+
+	upsertBatchSize := cvt.PtrToVal(c.UpsertBatchSize)
+	if upsertBatchSize <= 0 {
+		return fmt.Errorf("clbCondSync.upsertBatchSize should be greater than 0, but got %d", upsertBatchSize)
+	}
+
+	largeUpsertThreshold := cvt.PtrToVal(c.LargeUpsertThreshold)
+	if largeUpsertThreshold <= 0 {
+		return fmt.Errorf("clbCondSync.largeUpsertThreshold should be greater than 0, but got %d",
+			largeUpsertThreshold)
+	}
+
+	largeUpsertBatchSize := cvt.PtrToVal(c.LargeUpsertBatchSize)
+	if largeUpsertBatchSize <= 0 {
+		return fmt.Errorf("clbCondSync.largeUpsertBatchSize should be greater than 0, but got %d",
+			largeUpsertBatchSize)
+	}
+
+	listConcurrent := cvt.PtrToVal(c.ListConcurrent)
+	if listConcurrent <= 0 {
+		return fmt.Errorf("clbCondSync.listConcurrent should be greater than 0, but got %d", listConcurrent)
+	}
+
+	return nil
 }
 
 // AsyncFlowAndTaskCleanup 异步任务（async_flow / async_flow_task）历史数据定时清理配置。

--- a/pkg/client/hc-service/tcloud/clb.go
+++ b/pkg/client/hc-service/tcloud/clb.go
@@ -50,9 +50,38 @@ func (c *ClbClient) SyncLoadBalancer(kt *kit.Kit, req *sync.TCloudSyncReq) error
 	return common.RequestNoResp[sync.TCloudSyncReq](c.client, http.MethodPost, kt, req, "/load_balancers/sync")
 }
 
+// DeleteLoadBalancerByCond delete load balancer by condition.
+func (c *ClbClient) DeleteLoadBalancerByCond(kt *kit.Kit, req *sync.TCloudDelLoadBalancerByCondReq) error {
+
+	return common.RequestNoResp[sync.TCloudDelLoadBalancerByCondReq](
+		c.client, http.MethodDelete, kt, req, "/load_balancers/by_condition/delete")
+}
+
+// SyncLoadBalancerByCond sync load balancer by condition.
+func (c *ClbClient) SyncLoadBalancerByCond(kt *kit.Kit, req *sync.TCloudSyncLoadBalancerByCondReq) error {
+
+	return common.RequestNoResp[sync.TCloudSyncLoadBalancerByCondReq](
+		c.client, http.MethodPost, kt, req, "/load_balancers/by_condition/sync")
+}
+
 // SyncLoadBalancerListener 同步负载均衡下监听器
 func (c *ClbClient) SyncLoadBalancerListener(kt *kit.Kit, req *sync.TCloudListenerSyncReq) error {
 	return common.RequestNoResp[sync.TCloudListenerSyncReq](c.client, http.MethodPost, kt, req, "/listeners/sync")
+}
+
+// ListLoadBalancer 查询云上负载均衡列表
+func (c *ClbClient) ListLoadBalancer(kt *kit.Kit, req *hcproto.TCloudListOption) (*[]typelb.TCloudClb, error) {
+
+	return common.Request[hcproto.TCloudListOption, []typelb.TCloudClb](
+		c.client, http.MethodPost, kt, req, "/load_balancers/list")
+}
+
+// ListLoadBalancerWithCount 查询云上负载均衡列表及总数
+func (c *ClbClient) ListLoadBalancerWithCount(kt *kit.Kit, req *hcproto.TCloudListOption) (
+	*hcproto.TCloudListResult, error) {
+
+	return common.Request[hcproto.TCloudListOption, hcproto.TCloudListResult](
+		c.client, http.MethodPost, kt, req, "/load_balancers/list_with_count")
 }
 
 // DescribeResources ...

--- a/pkg/criteria/constant/clb.go
+++ b/pkg/criteria/constant/clb.go
@@ -31,6 +31,17 @@ const (
 	ListenerMinSessionExpire = 30
 	// ResFlowLockExpireDays 锁定资源与Flow的最大超时时间，默认7天
 	ResFlowLockExpireDays = 7
+	// DefaultCondSyncLbDeleteBatchSize 负载均衡条件同步中，单个清理任务动作处理的负载均衡数量默认值
+	DefaultCondSyncLbDeleteBatchSize = 100
+	// DefaultCondSyncLbUpsertBatchSize 负载均衡条件同步中，单个同步任务动作处理的负载均衡数量默认值
+	DefaultCondSyncLbUpsertBatchSize = 500
+	// DefaultCondSyncLbLargeUpsertThreshold 负载均衡条件同步中，判定本次同步为大规模的负载均衡数量默认阈值
+	DefaultCondSyncLbLargeUpsertThreshold = 10000
+	// DefaultCondSyncLbLargeUpsertBatchSize 负载均衡条件同步中，
+	// 待同步数量超过阈值后单个同步任务动作处理的负载均衡数量默认值
+	DefaultCondSyncLbLargeUpsertBatchSize = 2500
+	// DefaultCondSyncLbListConcurrent 负载均衡条件同步中，启动阶段拉取云上简要信息的分页并发默认值
+	DefaultCondSyncLbListConcurrent = 5
 	// FlowRetryTimeout Flow重试的最大重试超时
 	FlowRetryTimeout = 7 * 24 * time.Hour
 )
@@ -39,6 +50,9 @@ const (
 const (
 	// TCLBDescribeMax 腾讯云CLB默认查询大小
 	TCLBDescribeMax = 20
+	// TCLBDescribeQPSLimit 腾讯云查询负载均衡接口的出云QPS上限。
+	// 云上对 DescribeLoadBalancers 限频20次/秒，此处留出余量给同账号下的其他CLB接口调用。
+	TCLBDescribeQPSLimit = 20
 	// TCLBDeleteProtect 腾讯云负载均衡删除保护
 	TCLBDeleteProtect = "DeleteProtect"
 )

--- a/pkg/criteria/enumor/async_flow_name.go
+++ b/pkg/criteria/enumor/async_flow_name.go
@@ -85,6 +85,7 @@ var loadBalancerFlowNameMap = map[FlowName]struct{}{
 	FlowBatchTaskListenerUnBindTarget:   {},
 	FlowBatchTaskListenerModifyRsWeight: {},
 	FlowBatchTaskDeleteListener:         {},
+	FlowBatchTaskSyncLoadBalancer:       {},
 }
 
 // ValidateLoadBalancer validate load balancer FlowName.
@@ -162,6 +163,8 @@ const (
 	FlowBatchTaskListenerModifyRsWeight = "batch_task_tcloud_listener_modify_rs_weight"
 	// FlowBatchTaskDeleteListener 异步任务-批量删除监听器
 	FlowBatchTaskDeleteListener = "batch_task_tcloud_delete_listener"
+	// FlowBatchTaskSyncLoadBalancer 异步任务-批量同步负载均衡
+	FlowBatchTaskSyncLoadBalancer FlowName = "batch_task_sync_load_balancer"
 )
 
 // 账单相关Flow

--- a/pkg/criteria/enumor/async_task_name.go
+++ b/pkg/criteria/enumor/async_task_name.go
@@ -46,7 +46,8 @@ func (v ActionName) Validate() error {
 		ActionDailyAccountSplit, ActionDailyAccountSummary, ActionMonthTaskAction:
 	case ActionLoadBalancerDeleteUrlRule, ActionLoadBalancerDeleteListener:
 	case ActionBatchTaskTCloudCreateL7Rule, ActionBatchTaskTCloudBindTarget, ActionBatchTaskTCloudCreateListener,
-		ActionBatchTaskTCloudUnBindTarget, ActionBatchTaskTCloudModifyRsWeight, ActionBatchTaskDeleteListener:
+		ActionBatchTaskTCloudUnBindTarget, ActionBatchTaskTCloudModifyRsWeight, ActionBatchTaskDeleteListener,
+		ActionBatchTaskSyncLbDelete, ActionBatchTaskSyncLbUpsert:
 	case ActionSyncTCloudLoadBalancer, SyncTCloudLoadBalancerListener:
 
 	default:
@@ -148,6 +149,10 @@ const (
 	ActionBatchTaskTCloudModifyRsWeight = "batch_task_tcloud_listener_modify_rs_weight"
 	// ActionBatchTaskDeleteListener 异步任务-批量删除监听器
 	ActionBatchTaskDeleteListener ActionName = "batch_task_tcloud_delete_listener"
+	// ActionBatchTaskSyncLbDelete 异步任务-批量删除云上已不存在的负载均衡
+	ActionBatchTaskSyncLbDelete ActionName = "batch_task_sync_lb_delete"
+	// ActionBatchTaskSyncLbUpsert 异步任务-批量同步负载均衡
+	ActionBatchTaskSyncLbUpsert ActionName = "batch_task_sync_lb_upsert"
 )
 
 const (

--- a/pkg/criteria/enumor/load_balancer.go
+++ b/pkg/criteria/enumor/load_balancer.go
@@ -24,6 +24,18 @@ import (
 	"fmt"
 )
 
+// CondSyncLbOperation is the operation of a single CLB in a conditional sync task.
+type CondSyncLbOperation string
+
+const (
+	// CondSyncLbOpCreate 云上存在、DB不存在，需要新增
+	CondSyncLbOpCreate CondSyncLbOperation = "create"
+	// CondSyncLbOpUpdate 云上与DB都存在，需要更新
+	CondSyncLbOpUpdate CondSyncLbOperation = "update"
+	// CondSyncLbOpDelete 云上不存在、DB存在，需要清理
+	CondSyncLbOpDelete CondSyncLbOperation = "delete"
+)
+
 // RuleType 负载均衡类型
 type RuleType string
 

--- a/pkg/criteria/enumor/task.go
+++ b/pkg/criteria/enumor/task.go
@@ -164,4 +164,7 @@ const (
 	TaskTargetGroupModifyWeight TaskOperation = "target_group_modify_weight"
 	// TaskListenerAddTarget is a task indicating that add target to listener rule.
 	TaskListenerAddTarget TaskOperation = "listener_add_target"
+
+	// TaskSyncLoadBalancer is a task indicating that sync load balancer.
+	TaskSyncLoadBalancer TaskOperation = "sync_load_balancer"
 )

--- a/pkg/kit/kit.go
+++ b/pkg/kit/kit.go
@@ -29,10 +29,13 @@ import (
 	"hcm/pkg/cc"
 	"hcm/pkg/criteria/constant"
 	"hcm/pkg/criteria/enumor"
+	"hcm/pkg/logs"
 	"hcm/pkg/tools/converter"
 	"hcm/pkg/tools/rand"
 	"hcm/pkg/tools/uuid"
 )
+
+const maxRidLength = 50
 
 // New initial a kit with rid and context.
 func New() *Kit {
@@ -84,6 +87,12 @@ func (kt *Kit) NewSubKitWithSuffix(suffix string) *Kit {
 
 	newSubKit := converter.ValToPtr(*kt)
 	subRid := kt.Rid + "/" + suffix
+	if len(subRid) > maxRidLength {
+		// Keep the original rid when appending suffix would make the child request invalid.
+		logs.Warnf("skip sub rid suffix because rid length exceeds limit, parentRid: %s, suffix: %s, rid: %s",
+			kt.Rid, suffix, kt.Rid)
+		subRid = kt.Rid
+	}
 	newSubKit.Rid = subRid
 	newSubKit.Ctx = context.WithValue(kt.Ctx, constant.RidKey, subRid)
 	return newSubKit
@@ -163,7 +172,7 @@ func (kt *Kit) Validate() error {
 		return errors.New("rid is required")
 	}
 
-	if ridLen < 16 || ridLen > 50 {
+	if ridLen < 16 || ridLen > maxRidLength {
 		return errors.New("rid length not right, length should in 16~50")
 	}
 

--- a/pkg/tools/slice/slice.go
+++ b/pkg/tools/slice/slice.go
@@ -92,6 +92,16 @@ func Split[T any](list []T, length int) [][]T {
 	return lists
 }
 
+// First returns the first item in list, or zero value when list is empty.
+func First[T any](list []T) T {
+	var zero T
+	if len(list) == 0 {
+		return zero
+	}
+
+	return list[0]
+}
+
 // Map 对slice里面的每个元素执行mapFunc函数，返回新slice
 func Map[IType any, OType any](source []IType, mapFunc func(IType) OType) []OType {
 	target := make([]OType, 0, len(source))

--- a/pkg/tools/slice/slice_test.go
+++ b/pkg/tools/slice/slice_test.go
@@ -29,6 +29,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestFirst(t *testing.T) {
+	assert.Equal(t, "a", First([]string{"a", "b"}))
+	assert.Equal(t, "", First([]string{}))
+	assert.Equal(t, 1, First([]int{1, 2}))
+	assert.Equal(t, 0, First([]int{}))
+}
+
 func TestTopK(t *testing.T) {
 
 	type testCase[T any, SL []T] struct {


### PR DESCRIPTION
变更要点：
- CLB 条件同步改为创建 task_management/task_detail 并提交异步 flow
- 新增批量删除/同步 CLB task action，复用 hc-service 同步链路
- 使用 DescribeLoadBalancers 带 TotalCount 查询并支持按 cloud_id 分批并发拉取
- 业务入口收敛腾讯云 CLB 同步范围，避免同步业务外资源
- 增加任务详情批量回填、阶段耗时日志和相关单测